### PR TITLE
rename project-radius to radius-project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 # All of the people (and only those people) from the matching rule will be notified
 
 # Default rule: anything that doesn't match a more specific rule goes here
-* @project-radius/Radius-Eng @project-radius/Radius-PM
+* @radius-project/Radius-Eng @radius-project/Radius-PM

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -44,7 +44,7 @@ jobs:
         echo "## :x: Spellcheck Failed" >> $GITHUB_STEP_SUMMARY
         echo "There are spelling errors in your PR. Visit [the workflow output](${{ env.ACTION_LINK }}) to see what words are failing." >> $GITHUB_STEP_SUMMARY
         echo "### Adding new words" >> $GITHUB_STEP_SUMMARY
-        echo "You can add new custom words to [.github/config/en-custom.txt](https://github.com/project-radius/design-notes/blob/main/.github/config/en-custom.txt)." >> $GITHUB_STEP_SUMMARY
+        echo "You can add new custom words to [.github/config/en-custom.txt](https://github.com/radius-project/design-notes/blob/main/.github/config/en-custom.txt)." >> $GITHUB_STEP_SUMMARY
     - name: Post GitHub workflow output on success
       run: |
         echo "## :white_check_mark: Spellcheck Passed" >> $GITHUB_STEP_SUMMARY
@@ -59,7 +59,7 @@ jobs:
           ## :x: Spellcheck Failed
           There are spelling errors in your PR. Visit [the workflow output](${{ env.ACTION_LINK }}) to see what words are failing.
           ### Adding new words
-          You can add new custom words to [.github/config/en-custom.txt](https://github.com/project-radius/design-notes/blob/main/.github/config/en-custom.txt).
+          You can add new custom words to [.github/config/en-custom.txt](https://github.com/radius-project/design-notes/blob/main/.github/config/en-custom.txt).
     - name: Clear GitHub comment on success
       uses: marocchino/sticky-pull-request-comment@v2
       continue-on-error: true

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This `design-notes` repository contains design proposals, enhancements, and architectural decisions for Radius. It provides a consistent and controlled path to record changes and developments, ensuring clarity and transparency for all stakeholders in the Radius community.
 
-Design notes are used for evaluating the design of **planned** changes and additions to Radius. Do not use this repository for feature requests - please create an issue on the [main Radius repository](https://github.com/project-radius) instead. We create documents in this repo to describe **how** to accomplish something once we have agreement that it is appropriate for the project.
+Design notes are used for evaluating the design of **planned** changes and additions to Radius. Do not use this repository for feature requests - please create an issue on the [main Radius repository](https://github.com/radius-project) instead. We create documents in this repo to describe **how** to accomplish something once we have agreement that it is appropriate for the project.
 
 Minor changes such as documentation updates or small bug fixes may be reviewed and implemented directly via a GitHub issue. For larger changes, such as new feature design, a design note pull-request and review is required. These must get consensus from Radius maintainers and the community, and should follow the [design note template](./template/YYYY-MM-design-template.md) in this repository.
 
-For more information on how to contribute to Radius visit [CONTRIBUTING.md](https://github.com/project-radius/radius/blob/main/CONTRIBUTING.md).
+For more information on how to contribute to Radius visit [CONTRIBUTING.md](https://github.com/radius-project/radius/blob/main/CONTRIBUTING.md).
 
 ## Review note review process and instructions
 
@@ -71,4 +71,4 @@ The repository is organized into several sections, each corresponding to a speci
 
 ## Code of Conduct
 
-Please refer to our [Radius Community Code of Conduct](https://github.com/project-radius/radius/blob/main/CODE_OF_CONDUCT.md)
+Please refer to our [Radius Community Code of Conduct](https://github.com/radius-project/radius/blob/main/CODE_OF_CONDUCT.md)


### PR DESCRIPTION
As part of OSS effort, we should rename all occurrences of project-radius to radius-project in our repos.