### PR TITLE
Fix spellcheck for codeblocks

### DIFF
--- a/.github/config/.pyspelling.yml
+++ b/.github/config/.pyspelling.yml
@@ -9,6 +9,8 @@ matrix:
     - .github/config/en-custom.txt
   pipeline:
   - pyspelling.filters.markdown:
+      markdown_extensions:
+      - markdown.extensions.fenced_code
   - pyspelling.filters.html:
       comments: false
       ignores:


### PR DESCRIPTION
An extra plugin is needed here to get the spell checker to understand multi-line code blocks