### PR TITLE
Add workflow for stale pull requests

### DIFF
--- a/.github/workflows/stale-prs.yaml
+++ b/.github/workflows/stale-prs.yaml
@@ -1,0 +1,42 @@
+# ------------------------------------------------------------
+# Copyright 2023 The Radius Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#    
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ------------------------------------------------------------
+
+# See: https://github.com/actions/stale
+name: Stale pull requests
+on:
+  workflow_dispatch:
+  schedule:
+    # This is a cron job that runs every day at midnight
+    - cron: '0 0 * * *'
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+jobs:
+  stale-prs:
+    name: Check stale pull requests
+    runs-on: ubuntu-latest
+    steps:
+     - uses: actions/stale@v9
+       with:
+        stale-pr-message: |
+          This pull request is stale because it has been open 14 days with no activity. Remove stale label or comment or this will be closed in 7 days.
+        close-pr-message: |
+          This pull request has been closed due to inactivity. Feel free to reopen if you are still working on it.
+        days-before-stale: 14
+        days-before-close: 7
+        days-before-issue-stale: -1 # Ignore issues
+        days-before-issue-close: -1 # Ignore issues


### PR DESCRIPTION
Proposing some automation to help us keep design-notes clean. This will give a gentle nudge when a design-notes PR goes stale after 14 days, and then close the pull-request after an additional 7 days with no activity.