### PR TITLE
Add on-call team as codeowner for Dependabot updates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # These owners are the maintainers and approvers of this repo
 *       @radius-project/maintainers-design-notes @radius-project/approvers-design-notes
+
+# Files that Dependabot updates - on-call can also approve these
+.github/workflows/      @radius-project/maintainers-design-notes @radius-project/approvers-design-notes @radius-project/on-call


### PR DESCRIPTION
Add radius-project/on-call as additional codeowner for .github/workflows/ to allow dependency updates without blocking on maintainers/approvers.