### PR TITLE
Spec Kit 0.3.0 upgrade for scripts, agents, and templates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
+[*.{go,mod}]
+indent_style = tab
+
+[*.md]
+indent_size = unset
+
+[*.py]
+indent_size = 4
+
+[*.ps1]
+indent_size = 4
+
+[*.{cmd,bat}]
+end_of_line = crlf
+
+# Shell scripts
+[{*.sh,*.bash,.bashrc,.mk-sbuild.rc,.quiltrc,.startxwinrc,user-dirs.dirs}]
+binary_next_line = true         # shfmt: -bn
+switch_case_indent = true       # shfmt: -ci
+space_redirects = true          # shfmt: -sr
+keep_padding = true             # shfmt: -kp

--- a/.github/agents/speckit.analyze.agent.md
+++ b/.github/agents/speckit.analyze.agent.md
@@ -24,7 +24,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ### 1. Initialize Analysis Context
 
-Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` (Linux or macOS) or `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` (Windows) once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
 
 - SPEC = FEATURE_DIR/spec.md
 - PLAN = FEATURE_DIR/plan.md

--- a/.github/agents/speckit.analyze.agent.md
+++ b/.github/agents/speckit.analyze.agent.md
@@ -24,7 +24,7 @@ Identify inconsistencies, duplications, ambiguities, and underspecified items ac
 
 ### 1. Initialize Analysis Context
 
-Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` (Linux or macOS) or `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` (Windows) once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
+Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` once from repo root and parse JSON for FEATURE_DIR and AVAILABLE_DOCS. Derive absolute paths:
 
 - SPEC = FEATURE_DIR/spec.md
 - PLAN = FEATURE_DIR/plan.md

--- a/.github/agents/speckit.checklist.agent.md
+++ b/.github/agents/speckit.checklist.agent.md
@@ -91,9 +91,10 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Generate unique checklist filename:
      - Use short, descriptive name based on domain (e.g., `ux.md`, `api.md`, `security.md`)
      - Format: `[domain].md`
-     - If file exists, append to existing file
-   - Number items sequentially starting from CHK001
-   - Each `/speckit.checklist` run creates a NEW file (never overwrites existing checklists)
+   - File handling behavior:
+     - If file does NOT exist: Create new file and number items starting from CHK001
+     - If file exists: Append new items to existing file, continuing from the last CHK ID (e.g., if last item is CHK015, start new items at CHK016)
+   - Never delete or replace existing checklist content - always preserve and append
 
    **CORE PRINCIPLE - Test the Requirements, Not the Implementation**:
    Every checklist item MUST evaluate the REQUIREMENTS THEMSELVES for:
@@ -205,13 +206,13 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 6. **Structure Reference**: Generate the checklist following the canonical template in `.specify/templates/checklist-template.md` for title, meta section, category headings, and ID formatting. If template is unavailable, use: H1 title, purpose/created meta lines, `##` category sections containing `- [ ] CHK### <requirement item>` lines with globally incrementing IDs starting at CHK001.
 
-7. **Report**: Output full path to created checklist, item count, and remind user that each run creates a new file. Summarize:
+7. **Report**: Output full path to checklist file, item count, and summarize whether the run created a new file or appended to an existing one. Summarize:
    - Focus areas selected
    - Depth level
    - Actor/timing
    - Any explicit user-specified must-have items incorporated
 
-**Important**: Each `/speckit.checklist` command invocation creates a checklist file using short, descriptive names unless file already exists. This allows:
+**Important**: Each `/speckit.checklist` command invocation uses a short, descriptive checklist filename and either creates a new file or appends to an existing one. This allows:
 
 - Multiple checklists of different types (e.g., `ux.md`, `test.md`, `security.md`)
 - Simple, memorable filenames that indicate checklist purpose

--- a/.github/agents/speckit.clarify.agent.md
+++ b/.github/agents/speckit.clarify.agent.md
@@ -86,7 +86,7 @@ Execution steps:
    - Information is better deferred to planning phase (note internally)
 
 3. Generate (internally) a prioritized queue of candidate clarification questions (maximum 5). Do NOT output them all at once. Apply these constraints:
-    - Maximum of 10 total questions across the whole session.
+    - Maximum of 5 total questions across the whole session.
     - Each question must be answerable with EITHER:
        - A short multiple‑choice selection (2–5 distinct, mutually exclusive options), OR
        - A one-word / short‑phrase answer (explicitly constrain: "Answer in <=5 words").

--- a/.github/agents/speckit.constitution.agent.md
+++ b/.github/agents/speckit.constitution.agent.md
@@ -18,9 +18,11 @@ You **MUST** consider the user input before proceeding (if not empty).
 
 You are updating the project constitution at `.specify/memory/constitution.md`. This file is a TEMPLATE containing placeholder tokens in square brackets (e.g. `[PROJECT_NAME]`, `[PRINCIPLE_1_NAME]`). Your job is to (a) collect/derive concrete values, (b) fill the template precisely, and (c) propagate any amendments across dependent artifacts.
 
+**Note**: If `.specify/memory/constitution.md` does not exist yet, it should have been initialized from `.specify/templates/constitution-template.md` during project setup. If it's missing, copy the template first.
+
 Follow this execution flow:
 
-1. Load the existing constitution template at `.specify/memory/constitution.md`.
+1. Load the existing constitution at `.specify/memory/constitution.md`.
    - Identify every placeholder token of the form `[ALL_CAPS_IDENTIFIER]`.
    **IMPORTANT**: The user might require less or more principles than the ones used in the template. If a number is specified, respect that - follow the general template. You will update the doc accordingly.
 

--- a/.github/agents/speckit.implement.agent.md
+++ b/.github/agents/speckit.implement.agent.md
@@ -119,7 +119,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
    - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
    - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
-   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
    - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
    - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
    - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`

--- a/.github/agents/speckit.implement.agent.md
+++ b/.github/agents/speckit.implement.agent.md
@@ -10,6 +10,40 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before implementation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_implement` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter to only hooks where `enabled: true`
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 1. Run `.specify/scripts/bash/check-prerequisites.sh --json --require-tasks --include-tasks` (Linux or macOS) or `.specify/scripts/powershell/check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks` (Windows) from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
@@ -85,7 +119,7 @@ You **MUST** consider the user input before proceeding (if not empty).
    - **Rust**: `target/`, `debug/`, `release/`, `*.rs.bk`, `*.rlib`, `*.prof*`, `.idea/`, `*.log`, `.env*`
    - **Kotlin**: `build/`, `out/`, `.gradle/`, `.idea/`, `*.class`, `*.jar`, `*.iml`, `*.log`, `.env*`
    - **C++**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.so`, `*.a`, `*.exe`, `*.dll`, `.idea/`, `*.log`, `.env*`
-   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `Makefile`, `config.log`, `.idea/`, `*.log`, `.env*`
+   - **C**: `build/`, `bin/`, `obj/`, `out/`, `*.o`, `*.a`, `*.so`, `*.exe`, `*.dll`, `autom4te.cache/`, `config.status`, `config.log`, `.idea/`, `*.log`, `.env*`
    - **Swift**: `.build/`, `DerivedData/`, `*.swiftpm/`, `Packages/`
    - **R**: `.Rproj.user/`, `.Rhistory`, `.RData`, `.Ruserdata`, `*.Rproj`, `packrat/`, `renv/`
    - **Universal**: `.DS_Store`, `Thumbs.db`, `*.tmp`, `*.swp`, `.vscode/`, `.idea/`
@@ -133,3 +167,32 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Report final status with summary of completed work
 
 Note: This command assumes a complete task breakdown exists in tasks.md. If tasks are incomplete or missing, suggest running `/speckit.tasks` first to regenerate the task list.
+
+10. **Check for extension hooks**: After completion validation, check if `.specify/extensions.yml` exists in the project root.
+    - If it exists, read it and look for entries under the `hooks.after_implement` key
+    - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+    - Filter to only hooks where `enabled: true`
+    - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+      - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+      - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+    - For each executable hook, output the following based on its `optional` flag:
+      - **Optional hook** (`optional: true`):
+        ```
+        ## Extension Hooks
+
+        **Optional Hook**: {extension}
+        Command: `/{command}`
+        Description: {description}
+
+        Prompt: {prompt}
+        To execute: `/{command}`
+        ```
+      - **Mandatory hook** (`optional: false`):
+        ```
+        ## Extension Hooks
+
+        **Automatic Hook**: {extension}
+        Executing: `/{command}`
+        EXECUTE_COMMAND: {command}
+        ```
+    - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently

--- a/.github/agents/speckit.plan.agent.md
+++ b/.github/agents/speckit.plan.agent.md
@@ -69,10 +69,11 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Validation rules from requirements
    - State transitions if applicable
 
-2. **Generate API contracts** from functional requirements:
-   - For each user action → endpoint
-   - Use standard REST/GraphQL patterns
-   - Output OpenAPI/GraphQL schema to `/contracts/`
+2. **Define interface contracts** (if project has external interfaces) → `/contracts/`:
+   - Identify what interfaces the project exposes to users or other systems
+   - Document the contract format appropriate for the project type
+   - Examples: public APIs for libraries, command schemas for CLI tools, endpoints for web services, grammars for parsers, UI contracts for applications
+   - Skip if project is purely internal (build scripts, one-off tools, etc.)
 
 3. **Agent context update**:
    - Run `.specify/scripts/bash/update-agent-context.sh copilot` (Linux or macOS) or `.specify/scripts/powershell/update-agent-context.ps1 -AgentType copilot` (Windows)

--- a/.github/agents/speckit.specify.agent.md
+++ b/.github/agents/speckit.specify.agent.md
@@ -36,33 +36,14 @@ Given that feature description, do this:
      - "Create a dashboard for analytics" → "analytics-dashboard"
      - "Fix payment processing timeout bug" → "fix-payment-timeout"
 
-2. **Check for existing branches before creating new one**:
+2. **Create the feature branch** by running the script with `--short-name` (and `--json`), and do NOT pass `--number` (the script auto-detects the next globally available number across all branches and spec directories):
 
-   a. First, fetch all remote branches to ensure we have the latest information:
-
-      ```bash
-      git fetch --all --prune
-      ```
-
-   b. Find the highest feature number across all sources for the short-name:
-      - Remote branches: `git ls-remote --heads origin | grep -E 'refs/heads/[0-9]+-<short-name>$'`
-      - Local branches: `git branch | grep -E '^[* ]*[0-9]+-<short-name>$'`
-      - Specs directories: Check for directories matching `specs/[0-9]+-<short-name>`
-
-   c. Determine the next available number:
-      - Extract all numbers from all three sources
-      - Find the highest number N
-      - Use N+1 for the new branch number
-
-   d. Run the script `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS"` (Linux or macOS) or `.specify/scripts/powershell/create-new-feature.ps1 -Json "$ARGUMENTS"` (Windows) with the calculated number and short-name:
-      - Pass `--number N+1` and `--short-name "your-short-name"` along with the feature description
-      - Bash example: `.specify/scripts/bash/create-new-feature.sh --json "$ARGUMENTS" --number 5 --short-name "user-auth" "Add user authentication"`
-      - PowerShell example: `.specify/scripts/powershell/create-new-feature.ps1 -Json "$ARGUMENTS" -Json -Number 5 -ShortName "user-auth" "Add user authentication"`
+   - Bash example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" --json --short-name "user-auth" "Add user authentication"`
+   - PowerShell example: `.specify/scripts/bash/create-new-feature.sh "$ARGUMENTS" -Json -ShortName "user-auth" "Add user authentication"`
 
    **IMPORTANT**:
-   - Check all three sources (remote branches, local branches, specs directories) to find the highest number
-   - Only match branches/directories with the exact short-name pattern
-   - If no existing branches/directories found with this short-name, start with number 1
+   - Do NOT pass `--number` — the script determines the correct next number automatically
+   - Always include the JSON flag (`--json` for Bash, `-Json` for PowerShell) so the output can be parsed reliably
    - You must only ever run this script once per feature
    - The JSON is provided in the terminal as output - always refer to it to get the actual content you're looking for
    - The JSON output will contain BRANCH_NAME and SPEC_FILE paths
@@ -145,7 +126,7 @@ Given that feature description, do this:
 
    c. **Handle Validation Results**:
 
-      - **If all items pass**: Mark checklist complete and proceed to step 6
+      - **If all items pass**: Mark checklist complete and proceed to step 7
 
       - **If items fail (excluding [NEEDS CLARIFICATION])**:
         1. List the failing items and specific issues
@@ -194,8 +175,6 @@ Given that feature description, do this:
 
 **NOTE:** The script creates and checks out the new branch and initializes the spec file before writing.
 
-## General Guidelines
-
 ## Quick Guidelines
 
 - Focus on **WHAT** users need and **WHY**.
@@ -232,7 +211,7 @@ When creating this spec from a user prompt:
 - Performance targets: Standard web/mobile app expectations unless specified
 - Error handling: User-friendly messages with appropriate fallbacks
 - Authentication method: Standard session-based or OAuth2 for web apps
-- Integration patterns: RESTful APIs unless specified otherwise
+- Integration patterns: Use project-appropriate patterns (REST/GraphQL for web services, function calls for libraries, CLI args for tools, etc.)
 
 ### Success Criteria Guidelines
 

--- a/.github/agents/speckit.tasks.agent.md
+++ b/.github/agents/speckit.tasks.agent.md
@@ -19,20 +19,54 @@ $ARGUMENTS
 
 You **MUST** consider the user input before proceeding (if not empty).
 
+## Pre-Execution Checks
+
+**Check for extension hooks (before tasks generation)**:
+- Check if `.specify/extensions.yml` exists in the project root.
+- If it exists, read it and look for entries under the `hooks.before_tasks` key
+- If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+- Filter to only hooks where `enabled: true`
+- For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+  - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+  - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+- For each executable hook, output the following based on its `optional` flag:
+  - **Optional hook** (`optional: true`):
+    ```
+    ## Extension Hooks
+
+    **Optional Pre-Hook**: {extension}
+    Command: `/{command}`
+    Description: {description}
+
+    Prompt: {prompt}
+    To execute: `/{command}`
+    ```
+  - **Mandatory hook** (`optional: false`):
+    ```
+    ## Extension Hooks
+
+    **Automatic Pre-Hook**: {extension}
+    Executing: `/{command}`
+    EXECUTE_COMMAND: {command}
+    
+    Wait for the result of the hook command before proceeding to the Outline.
+    ```
+- If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
+
 ## Outline
 
 1. **Setup**: Run `.specify/scripts/bash/check-prerequisites.sh --json` (Linux or macOS) or `.specify/scripts/powershell/check-prerequisites.ps1 -Json` (Windows) from repo root and parse FEATURE_DIR and AVAILABLE_DOCS list. All paths must be absolute. For single quotes in args like "I'm Groot", use escape syntax: e.g 'I'\''m Groot' (or double-quote if possible: "I'm Groot").
 
 2. **Load design documents**: Read from FEATURE_DIR:
    - **Required**: plan.md (tech stack, libraries, structure), spec.md (user stories with priorities)
-   - **Optional**: data-model.md (entities), contracts/ (API endpoints), research.md (decisions), quickstart.md (test scenarios)
+   - **Optional**: data-model.md (entities), contracts/ (interface contracts), research.md (decisions), quickstart.md (test scenarios)
    - Note: Not all projects have all documents. Generate tasks based on what's available.
 
 3. **Execute task generation workflow**:
    - Load plan.md and extract tech stack, libraries, project structure
    - Load spec.md and extract user stories with their priorities (P1, P2, P3, etc.)
    - If data-model.md exists: Extract entities and map to user stories
-   - If contracts/ exists: Map endpoints to user stories
+   - If contracts/ exists: Map interface contracts to user stories
    - If research.md exists: Extract decisions for setup tasks
    - Generate tasks organized by user story (see Task Generation Rules below)
    - Generate dependency graph showing user story completion order
@@ -59,6 +93,35 @@ You **MUST** consider the user input before proceeding (if not empty).
    - Independent test criteria for each story
    - Suggested MVP scope (typically just User Story 1)
    - Format validation: Confirm ALL tasks follow the checklist format (checkbox, ID, labels, file paths)
+
+6. **Check for extension hooks**: After tasks.md is generated, check if `.specify/extensions.yml` exists in the project root.
+   - If it exists, read it and look for entries under the `hooks.after_tasks` key
+   - If the YAML cannot be parsed or is invalid, skip hook checking silently and continue normally
+   - Filter to only hooks where `enabled: true`
+   - For each remaining hook, do **not** attempt to interpret or evaluate hook `condition` expressions:
+     - If the hook has no `condition` field, or it is null/empty, treat the hook as executable
+     - If the hook defines a non-empty `condition`, skip the hook and leave condition evaluation to the HookExecutor implementation
+   - For each executable hook, output the following based on its `optional` flag:
+     - **Optional hook** (`optional: true`):
+       ```
+       ## Extension Hooks
+
+       **Optional Hook**: {extension}
+       Command: `/{command}`
+       Description: {description}
+
+       Prompt: {prompt}
+       To execute: `/{command}`
+       ```
+     - **Mandatory hook** (`optional: false`):
+       ```
+       ## Extension Hooks
+
+       **Automatic Hook**: {extension}
+       Executing: `/{command}`
+       EXECUTE_COMMAND: {command}
+       ```
+   - If no hooks are registered or `.specify/extensions.yml` does not exist, skip silently
 
 Context for task generation: $ARGUMENTS
 
@@ -109,13 +172,13 @@ Every task MUST strictly follow this format:
    - Map all related components to their story:
      - Models needed for that story
      - Services needed for that story
-     - Endpoints/UI needed for that story
+     - Interfaces/UI needed for that story
      - If tests requested: Tests specific to that story
    - Mark story dependencies (most stories should be independent)
 
 2. **From Contracts**:
-   - Map each contract/endpoint → to the user story it serves
-   - If tests requested: Each contract → contract test task [P] before implementation in that story's phase
+   - Map each interface contract → to the user story it serves
+   - If tests requested: Each interface contract → contract test task [P] before implementation in that story's phase
 
 3. **From Data Model**:
    - Map each entity to the user story(ies) that need it

--- a/.specify/init-options.json
+++ b/.specify/init-options.json
@@ -1,0 +1,9 @@
+{
+  "ai": "copilot",
+  "ai_commands_dir": null,
+  "ai_skills": false,
+  "here": true,
+  "preset": null,
+  "script": "sh",
+  "speckit_version": "0.3.0"
+}

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -29,20 +29,20 @@ PATHS_ONLY=false
 
 for arg in "$@"; do
     case "$arg" in
-        --json)
-            JSON_MODE=true
-            ;;
-        --require-tasks)
-            REQUIRE_TASKS=true
-            ;;
-        --include-tasks)
-            INCLUDE_TASKS=true
-            ;;
-        --paths-only)
-            PATHS_ONLY=true
-            ;;
-        --help|-h)
-            cat << 'EOF'
+    --json)
+        JSON_MODE=true
+        ;;
+    --require-tasks)
+        REQUIRE_TASKS=true
+        ;;
+    --include-tasks)
+        INCLUDE_TASKS=true
+        ;;
+    --paths-only)
+        PATHS_ONLY=true
+        ;;
+    --help | -h)
+        cat <<'EOF'
 Usage: check-prerequisites.sh [OPTIONS]
 
 Consolidated prerequisite checking for Spec-Driven Development workflow.
@@ -65,12 +65,12 @@ EXAMPLES:
   ./check-prerequisites.sh --paths-only
   
 EOF
-            exit 0
-            ;;
-        *)
-            echo "ERROR: Unknown option '$arg'. Use --help for usage information." >&2
-            exit 1
-            ;;
+        exit 0
+        ;;
+    *)
+        echo "ERROR: Unknown option '$arg'. Use --help for usage information." >&2
+        exit 1
+        ;;
     esac
 done
 
@@ -79,7 +79,10 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch
-_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+_paths_output=$(get_feature_paths) || {
+    echo "ERROR: Failed to resolve feature paths" >&2
+    exit 1
+}
 eval "$_paths_output"
 unset _paths_output
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
@@ -177,13 +180,13 @@ else
     # Text output
     echo "FEATURE_DIR:$FEATURE_DIR"
     echo "AVAILABLE_DOCS:"
-    
+
     # Show status of each potential document
     check_file "$RESEARCH" "research.md"
     check_file "$DATA_MODEL" "data-model.md"
     check_dir "$CONTRACTS_DIR" "contracts/"
     check_file "$QUICKSTART" "quickstart.md"
-    
+
     if $INCLUDE_TASKS; then
         check_file "$TASKS" "tasks.md"
     fi

--- a/.specify/scripts/bash/check-prerequisites.sh
+++ b/.specify/scripts/bash/check-prerequisites.sh
@@ -28,21 +28,21 @@ INCLUDE_TASKS=false
 PATHS_ONLY=false
 
 for arg in "$@"; do
-  case "$arg" in
-    --json)
-      JSON_MODE=true
-      ;;
-    --require-tasks)
-      REQUIRE_TASKS=true
-      ;;
-    --include-tasks)
-      INCLUDE_TASKS=true
-      ;;
-    --paths-only)
-      PATHS_ONLY=true
-      ;;
-    --help | -h)
-      cat <<'EOF'
+    case "$arg" in
+        --json)
+            JSON_MODE=true
+            ;;
+        --require-tasks)
+            REQUIRE_TASKS=true
+            ;;
+        --include-tasks)
+            INCLUDE_TASKS=true
+            ;;
+        --paths-only)
+            PATHS_ONLY=true
+            ;;
+        --help|-h)
+            cat << 'EOF'
 Usage: check-prerequisites.sh [OPTIONS]
 
 Consolidated prerequisite checking for Spec-Driven Development workflow.
@@ -65,13 +65,13 @@ EXAMPLES:
   ./check-prerequisites.sh --paths-only
   
 EOF
-      exit 0
-      ;;
-    *)
-      echo "ERROR: Unknown option '$arg'. Use --help for usage information." >&2
-      exit 1
-      ;;
-  esac
+            exit 0
+            ;;
+        *)
+            echo "ERROR: Unknown option '$arg'. Use --help for usage information." >&2
+            exit 1
+            ;;
+    esac
 done
 
 # Source common functions
@@ -79,44 +79,57 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get feature paths and validate branch
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 
 # If paths-only mode, output paths and exit (support JSON + paths-only combined)
 if $PATHS_ONLY; then
-  if $JSON_MODE; then
-    # Minimal JSON paths payload (no validation performed)
-    printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
-      "$REPO_ROOT" "$CURRENT_BRANCH" "$FEATURE_DIR" "$FEATURE_SPEC" "$IMPL_PLAN" "$TASKS"
-  else
-    echo "REPO_ROOT: $REPO_ROOT"
-    echo "BRANCH: $CURRENT_BRANCH"
-    echo "FEATURE_DIR: $FEATURE_DIR"
-    echo "FEATURE_SPEC: $FEATURE_SPEC"
-    echo "IMPL_PLAN: $IMPL_PLAN"
-    echo "TASKS: $TASKS"
-  fi
-  exit 0
+    if $JSON_MODE; then
+        # Minimal JSON paths payload (no validation performed)
+        if has_jq; then
+            jq -cn \
+                --arg repo_root "$REPO_ROOT" \
+                --arg branch "$CURRENT_BRANCH" \
+                --arg feature_dir "$FEATURE_DIR" \
+                --arg feature_spec "$FEATURE_SPEC" \
+                --arg impl_plan "$IMPL_PLAN" \
+                --arg tasks "$TASKS" \
+                '{REPO_ROOT:$repo_root,BRANCH:$branch,FEATURE_DIR:$feature_dir,FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,TASKS:$tasks}'
+        else
+            printf '{"REPO_ROOT":"%s","BRANCH":"%s","FEATURE_DIR":"%s","FEATURE_SPEC":"%s","IMPL_PLAN":"%s","TASKS":"%s"}\n' \
+                "$(json_escape "$REPO_ROOT")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$TASKS")"
+        fi
+    else
+        echo "REPO_ROOT: $REPO_ROOT"
+        echo "BRANCH: $CURRENT_BRANCH"
+        echo "FEATURE_DIR: $FEATURE_DIR"
+        echo "FEATURE_SPEC: $FEATURE_SPEC"
+        echo "IMPL_PLAN: $IMPL_PLAN"
+        echo "TASKS: $TASKS"
+    fi
+    exit 0
 fi
 
 # Validate required directories and files
 if [[ ! -d "$FEATURE_DIR" ]]; then
-  echo "ERROR: Feature directory not found: $FEATURE_DIR" >&2
-  echo "Run /speckit.specify first to create the feature structure." >&2
-  exit 1
+    echo "ERROR: Feature directory not found: $FEATURE_DIR" >&2
+    echo "Run /speckit.specify first to create the feature structure." >&2
+    exit 1
 fi
 
 if [[ ! -f "$IMPL_PLAN" ]]; then
-  echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
-  echo "Run /speckit.plan first to create the implementation plan." >&2
-  exit 1
+    echo "ERROR: plan.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit.plan first to create the implementation plan." >&2
+    exit 1
 fi
 
 # Check for tasks.md if required
 if $REQUIRE_TASKS && [[ ! -f "$TASKS" ]]; then
-  echo "ERROR: tasks.md not found in $FEATURE_DIR" >&2
-  echo "Run /speckit.tasks first to create the task list." >&2
-  exit 1
+    echo "ERROR: tasks.md not found in $FEATURE_DIR" >&2
+    echo "Run /speckit.tasks first to create the task list." >&2
+    exit 1
 fi
 
 # Build list of available documents
@@ -128,39 +141,50 @@ docs=()
 
 # Check contracts directory (only if it exists and has files)
 if [[ -d "$CONTRACTS_DIR" ]] && [[ -n "$(ls -A "$CONTRACTS_DIR" 2>/dev/null)" ]]; then
-  docs+=("contracts/")
+    docs+=("contracts/")
 fi
 
 [[ -f "$QUICKSTART" ]] && docs+=("quickstart.md")
 
 # Include tasks.md if requested and it exists
 if $INCLUDE_TASKS && [[ -f "$TASKS" ]]; then
-  docs+=("tasks.md")
+    docs+=("tasks.md")
 fi
 
 # Output results
 if $JSON_MODE; then
-  # Build JSON array of documents
-  if [[ ${#docs[@]} -eq 0 ]]; then
-    json_docs="[]"
-  else
-    json_docs=$(printf '"%s",' "${docs[@]}")
-    json_docs="[${json_docs%,}]"
-  fi
-
-  printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$FEATURE_DIR" "$json_docs"
+    # Build JSON array of documents
+    if has_jq; then
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '%s\n' "${docs[@]}" | jq -R . | jq -s .)
+        fi
+        jq -cn \
+            --arg feature_dir "$FEATURE_DIR" \
+            --argjson docs "$json_docs" \
+            '{FEATURE_DIR:$feature_dir,AVAILABLE_DOCS:$docs}'
+    else
+        if [[ ${#docs[@]} -eq 0 ]]; then
+            json_docs="[]"
+        else
+            json_docs=$(printf '"%s",' "${docs[@]}")
+            json_docs="[${json_docs%,}]"
+        fi
+        printf '{"FEATURE_DIR":"%s","AVAILABLE_DOCS":%s}\n' "$(json_escape "$FEATURE_DIR")" "$json_docs"
+    fi
 else
-  # Text output
-  echo "FEATURE_DIR:$FEATURE_DIR"
-  echo "AVAILABLE_DOCS:"
-
-  # Show status of each potential document
-  check_file "$RESEARCH" "research.md"
-  check_file "$DATA_MODEL" "data-model.md"
-  check_dir "$CONTRACTS_DIR" "contracts/"
-  check_file "$QUICKSTART" "quickstart.md"
-
-  if $INCLUDE_TASKS; then
-    check_file "$TASKS" "tasks.md"
-  fi
+    # Text output
+    echo "FEATURE_DIR:$FEATURE_DIR"
+    echo "AVAILABLE_DOCS:"
+    
+    # Show status of each potential document
+    check_file "$RESEARCH" "research.md"
+    check_file "$DATA_MODEL" "data-model.md"
+    check_dir "$CONTRACTS_DIR" "contracts/"
+    check_file "$QUICKSTART" "quickstart.md"
+    
+    if $INCLUDE_TASKS; then
+        check_file "$TASKS" "tasks.md"
+    fi
 fi

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -54,7 +54,7 @@ get_current_branch() {
         fi
     fi
 
-    echo "main"  # Final fallback
+    echo "main" # Final fallback
 }
 
 # Check if we have git available
@@ -211,7 +211,7 @@ except Exception:
                 while IFS= read -r preset_id; do
                     local candidate="$presets_dir/$preset_id/templates/${template_name}.md"
                     [ -f "$candidate" ] && echo "$candidate" && return 0
-                done <<< "$sorted_presets"
+                done <<<"$sorted_presets"
             else
                 # python3 returned empty list — fall through to directory scan
                 for preset in "$presets_dir"/*/; do
@@ -236,7 +236,7 @@ except Exception:
         for ext in "$ext_dir"/*/; do
             [ -d "$ext" ] || continue
             # Skip hidden directories (e.g. .backup, .cache)
-            case "$(basename "$ext")" in .*) continue;; esac
+            case "$(basename "$ext")" in .*) continue ;; esac
             local candidate="$ext/templates/${template_name}.md"
             [ -f "$candidate" ] && echo "$candidate" && return 0
         done
@@ -250,4 +250,3 @@ except Exception:
     # callers check [ -n "$TEMPLATE" ] to detect "not found".
     return 0
 }
-

--- a/.specify/scripts/bash/common.sh
+++ b/.specify/scripts/bash/common.sh
@@ -3,82 +3,82 @@
 
 # Get repository root, with fallback for non-git repositories
 get_repo_root() {
-  if git rev-parse --show-toplevel >/dev/null 2>&1; then
-    git rev-parse --show-toplevel
-  else
-    # Fall back to script location for non-git repos
-    local script_dir="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-    (cd "$script_dir/../../.." && pwd)
-  fi
+    if git rev-parse --show-toplevel >/dev/null 2>&1; then
+        git rev-parse --show-toplevel
+    else
+        # Fall back to script location for non-git repos
+        local script_dir="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        (cd "$script_dir/../../.." && pwd)
+    fi
 }
 
 # Get current branch, with fallback for non-git repositories
 get_current_branch() {
-  # First check if SPECIFY_FEATURE environment variable is set
-  if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
-    echo "$SPECIFY_FEATURE"
-    return
-  fi
-
-  # Then check git if available
-  if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
-    git rev-parse --abbrev-ref HEAD
-    return
-  fi
-
-  # For non-git repos, try to find the latest feature directory
-  local repo_root=$(get_repo_root)
-  local specs_dir="$repo_root/specs"
-
-  if [[ -d "$specs_dir" ]]; then
-    local latest_feature=""
-    local highest=0
-
-    for dir in "$specs_dir"/*; do
-      if [[ -d "$dir" ]]; then
-        local dirname=$(basename "$dir")
-        if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
-          local number=${BASH_REMATCH[1]}
-          number=$((10#$number))
-          if [[ "$number" -gt "$highest" ]]; then
-            highest=$number
-            latest_feature=$dirname
-          fi
-        fi
-      fi
-    done
-
-    if [[ -n "$latest_feature" ]]; then
-      echo "$latest_feature"
-      return
+    # First check if SPECIFY_FEATURE environment variable is set
+    if [[ -n "${SPECIFY_FEATURE:-}" ]]; then
+        echo "$SPECIFY_FEATURE"
+        return
     fi
-  fi
 
-  echo "main" # Final fallback
+    # Then check git if available
+    if git rev-parse --abbrev-ref HEAD >/dev/null 2>&1; then
+        git rev-parse --abbrev-ref HEAD
+        return
+    fi
+
+    # For non-git repos, try to find the latest feature directory
+    local repo_root=$(get_repo_root)
+    local specs_dir="$repo_root/specs"
+
+    if [[ -d "$specs_dir" ]]; then
+        local latest_feature=""
+        local highest=0
+
+        for dir in "$specs_dir"/*; do
+            if [[ -d "$dir" ]]; then
+                local dirname=$(basename "$dir")
+                if [[ "$dirname" =~ ^([0-9]{3})- ]]; then
+                    local number=${BASH_REMATCH[1]}
+                    number=$((10#$number))
+                    if [[ "$number" -gt "$highest" ]]; then
+                        highest=$number
+                        latest_feature=$dirname
+                    fi
+                fi
+            fi
+        done
+
+        if [[ -n "$latest_feature" ]]; then
+            echo "$latest_feature"
+            return
+        fi
+    fi
+
+    echo "main"  # Final fallback
 }
 
 # Check if we have git available
 has_git() {
-  git rev-parse --show-toplevel >/dev/null 2>&1
+    git rev-parse --show-toplevel >/dev/null 2>&1
 }
 
 check_feature_branch() {
-  local branch="$1"
-  local has_git_repo="$2"
+    local branch="$1"
+    local has_git_repo="$2"
 
-  # For non-git repos, we can't enforce branch naming but still provide output
-  if [[ "$has_git_repo" != "true" ]]; then
-    echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+    # For non-git repos, we can't enforce branch naming but still provide output
+    if [[ "$has_git_repo" != "true" ]]; then
+        echo "[specify] Warning: Git repository not detected; skipped branch validation" >&2
+        return 0
+    fi
+
+    if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
+        echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
+        echo "Feature branches should be named like: 001-feature-name" >&2
+        return 1
+    fi
+
     return 0
-  fi
-
-  if [[ ! "$branch" =~ ^[0-9]{3}- ]]; then
-    echo "ERROR: Not on a feature branch. Current branch: $branch" >&2
-    echo "Feature branches should be named like: 001-feature-name" >&2
-    return 1
-  fi
-
-  return 0
 }
 
 get_feature_dir() { echo "$1/specs/$2"; }
@@ -86,70 +86,168 @@ get_feature_dir() { echo "$1/specs/$2"; }
 # Find feature directory by numeric prefix instead of exact branch match
 # This allows multiple branches to work on the same spec (e.g., 004-fix-bug, 004-add-feature)
 find_feature_dir_by_prefix() {
-  local repo_root="$1"
-  local branch_name="$2"
-  local specs_dir="$repo_root/specs"
+    local repo_root="$1"
+    local branch_name="$2"
+    local specs_dir="$repo_root/specs"
 
-  # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
-  if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
-    # If branch doesn't have numeric prefix, fall back to exact match
-    echo "$specs_dir/$branch_name"
-    return
-  fi
+    # Extract numeric prefix from branch (e.g., "004" from "004-whatever")
+    if [[ ! "$branch_name" =~ ^([0-9]{3})- ]]; then
+        # If branch doesn't have numeric prefix, fall back to exact match
+        echo "$specs_dir/$branch_name"
+        return
+    fi
 
-  local prefix="${BASH_REMATCH[1]}"
+    local prefix="${BASH_REMATCH[1]}"
 
-  # Search for directories in specs/ that start with this prefix
-  local matches=()
-  if [[ -d "$specs_dir" ]]; then
-    for dir in "$specs_dir"/"$prefix"-*; do
-      if [[ -d "$dir" ]]; then
-        matches+=("$(basename "$dir")")
-      fi
-    done
-  fi
+    # Search for directories in specs/ that start with this prefix
+    local matches=()
+    if [[ -d "$specs_dir" ]]; then
+        for dir in "$specs_dir"/"$prefix"-*; do
+            if [[ -d "$dir" ]]; then
+                matches+=("$(basename "$dir")")
+            fi
+        done
+    fi
 
-  # Handle results
-  if [[ ${#matches[@]} -eq 0 ]]; then
-    # No match found - return the branch name path (will fail later with clear error)
-    echo "$specs_dir/$branch_name"
-  elif [[ ${#matches[@]} -eq 1 ]]; then
-    # Exactly one match - perfect!
-    echo "$specs_dir/${matches[0]}"
-  else
-    # Multiple matches - this shouldn't happen with proper naming convention
-    echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
-    echo "Please ensure only one spec directory exists per numeric prefix." >&2
-    echo "$specs_dir/$branch_name" # Return something to avoid breaking the script
-  fi
+    # Handle results
+    if [[ ${#matches[@]} -eq 0 ]]; then
+        # No match found - return the branch name path (will fail later with clear error)
+        echo "$specs_dir/$branch_name"
+    elif [[ ${#matches[@]} -eq 1 ]]; then
+        # Exactly one match - perfect!
+        echo "$specs_dir/${matches[0]}"
+    else
+        # Multiple matches - this shouldn't happen with proper naming convention
+        echo "ERROR: Multiple spec directories found with prefix '$prefix': ${matches[*]}" >&2
+        echo "Please ensure only one spec directory exists per numeric prefix." >&2
+        return 1
+    fi
 }
 
 get_feature_paths() {
-  local repo_root=$(get_repo_root)
-  local current_branch=$(get_current_branch)
-  local has_git_repo="false"
+    local repo_root=$(get_repo_root)
+    local current_branch=$(get_current_branch)
+    local has_git_repo="false"
 
-  if has_git; then
-    has_git_repo="true"
-  fi
+    if has_git; then
+        has_git_repo="true"
+    fi
 
-  # Use prefix-based lookup to support multiple branches per spec
-  local feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch")
+    # Use prefix-based lookup to support multiple branches per spec
+    local feature_dir
+    if ! feature_dir=$(find_feature_dir_by_prefix "$repo_root" "$current_branch"); then
+        echo "ERROR: Failed to resolve feature directory" >&2
+        return 1
+    fi
 
-  cat <<EOF
-REPO_ROOT='$repo_root'
-CURRENT_BRANCH='$current_branch'
-HAS_GIT='$has_git_repo'
-FEATURE_DIR='$feature_dir'
-FEATURE_SPEC='$feature_dir/spec.md'
-IMPL_PLAN='$feature_dir/plan.md'
-TASKS='$feature_dir/tasks.md'
-RESEARCH='$feature_dir/research.md'
-DATA_MODEL='$feature_dir/data-model.md'
-QUICKSTART='$feature_dir/quickstart.md'
-CONTRACTS_DIR='$feature_dir/contracts'
-EOF
+    # Use printf '%q' to safely quote values, preventing shell injection
+    # via crafted branch names or paths containing special characters
+    printf 'REPO_ROOT=%q\n' "$repo_root"
+    printf 'CURRENT_BRANCH=%q\n' "$current_branch"
+    printf 'HAS_GIT=%q\n' "$has_git_repo"
+    printf 'FEATURE_DIR=%q\n' "$feature_dir"
+    printf 'FEATURE_SPEC=%q\n' "$feature_dir/spec.md"
+    printf 'IMPL_PLAN=%q\n' "$feature_dir/plan.md"
+    printf 'TASKS=%q\n' "$feature_dir/tasks.md"
+    printf 'RESEARCH=%q\n' "$feature_dir/research.md"
+    printf 'DATA_MODEL=%q\n' "$feature_dir/data-model.md"
+    printf 'QUICKSTART=%q\n' "$feature_dir/quickstart.md"
+    printf 'CONTRACTS_DIR=%q\n' "$feature_dir/contracts"
+}
+
+# Check if jq is available for safe JSON construction
+has_jq() {
+    command -v jq >/dev/null 2>&1
+}
+
+# Escape a string for safe embedding in a JSON value (fallback when jq is unavailable).
+# Handles backslash, double-quote, and control characters (newline, tab, carriage return).
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    printf '%s' "$s"
 }
 
 check_file() { [[ -f "$1" ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
 check_dir() { [[ -d "$1" && -n $(ls -A "$1" 2>/dev/null) ]] && echo "  ✓ $2" || echo "  ✗ $2"; }
+
+# Resolve a template name to a file path using the priority stack:
+#   1. .specify/templates/overrides/
+#   2. .specify/presets/<preset-id>/templates/ (sorted by priority from .registry)
+#   3. .specify/extensions/<ext-id>/templates/
+#   4. .specify/templates/ (core)
+resolve_template() {
+    local template_name="$1"
+    local repo_root="$2"
+    local base="$repo_root/.specify/templates"
+
+    # Priority 1: Project overrides
+    local override="$base/overrides/${template_name}.md"
+    [ -f "$override" ] && echo "$override" && return 0
+
+    # Priority 2: Installed presets (sorted by priority from .registry)
+    local presets_dir="$repo_root/.specify/presets"
+    if [ -d "$presets_dir" ]; then
+        local registry_file="$presets_dir/.registry"
+        if [ -f "$registry_file" ] && command -v python3 >/dev/null 2>&1; then
+            # Read preset IDs sorted by priority (lower number = higher precedence)
+            local sorted_presets
+            sorted_presets=$(SPECKIT_REGISTRY="$registry_file" python3 -c "
+import json, sys, os
+try:
+    with open(os.environ['SPECKIT_REGISTRY']) as f:
+        data = json.load(f)
+    presets = data.get('presets', {})
+    for pid, meta in sorted(presets.items(), key=lambda x: x[1].get('priority', 10)):
+        print(pid)
+except Exception:
+    sys.exit(1)
+" 2>/dev/null)
+            if [ $? -eq 0 ] && [ -n "$sorted_presets" ]; then
+                while IFS= read -r preset_id; do
+                    local candidate="$presets_dir/$preset_id/templates/${template_name}.md"
+                    [ -f "$candidate" ] && echo "$candidate" && return 0
+                done <<< "$sorted_presets"
+            else
+                # python3 returned empty list — fall through to directory scan
+                for preset in "$presets_dir"/*/; do
+                    [ -d "$preset" ] || continue
+                    local candidate="$preset/templates/${template_name}.md"
+                    [ -f "$candidate" ] && echo "$candidate" && return 0
+                done
+            fi
+        else
+            # Fallback: alphabetical directory order (no python3 available)
+            for preset in "$presets_dir"/*/; do
+                [ -d "$preset" ] || continue
+                local candidate="$preset/templates/${template_name}.md"
+                [ -f "$candidate" ] && echo "$candidate" && return 0
+            done
+        fi
+    fi
+
+    # Priority 3: Extension-provided templates
+    local ext_dir="$repo_root/.specify/extensions"
+    if [ -d "$ext_dir" ]; then
+        for ext in "$ext_dir"/*/; do
+            [ -d "$ext" ] || continue
+            # Skip hidden directories (e.g. .backup, .cache)
+            case "$(basename "$ext")" in .*) continue;; esac
+            local candidate="$ext/templates/${template_name}.md"
+            [ -f "$candidate" ] && echo "$candidate" && return 0
+        done
+    fi
+
+    # Priority 4: Core templates
+    local core="$base/${template_name}.md"
+    [ -f "$core" ] && echo "$core" && return 0
+
+    # Return success with empty output so callers using set -e don't abort;
+    # callers check [ -n "$TEMPLATE" ] to detect "not found".
+    return 0
+}
+

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -10,53 +10,53 @@ i=1
 while [ $i -le $# ]; do
     arg="${!i}"
     case "$arg" in
-        --json) 
-            JSON_MODE=true 
-            ;;
-        --short-name)
-            if [ $((i + 1)) -gt $# ]; then
-                echo 'Error: --short-name requires a value' >&2
-                exit 1
-            fi
-            i=$((i + 1))
-            next_arg="${!i}"
-            # Check if the next argument is another option (starts with --)
-            if [[ "$next_arg" == --* ]]; then
-                echo 'Error: --short-name requires a value' >&2
-                exit 1
-            fi
-            SHORT_NAME="$next_arg"
-            ;;
-        --number)
-            if [ $((i + 1)) -gt $# ]; then
-                echo 'Error: --number requires a value' >&2
-                exit 1
-            fi
-            i=$((i + 1))
-            next_arg="${!i}"
-            if [[ "$next_arg" == --* ]]; then
-                echo 'Error: --number requires a value' >&2
-                exit 1
-            fi
-            BRANCH_NUMBER="$next_arg"
-            ;;
-        --help|-h) 
-            echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
-            echo ""
-            echo "Options:"
-            echo "  --json              Output in JSON format"
-            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
-            echo "  --number N          Specify branch number manually (overrides auto-detection)"
-            echo "  --help, -h          Show this help message"
-            echo ""
-            echo "Examples:"
-            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
-            echo "  $0 'Implement OAuth2 integration for API' --number 5"
-            exit 0
-            ;;
-        *) 
-            ARGS+=("$arg") 
-            ;;
+    --json)
+        JSON_MODE=true
+        ;;
+    --short-name)
+        if [ $((i + 1)) -gt $# ]; then
+            echo 'Error: --short-name requires a value' >&2
+            exit 1
+        fi
+        i=$((i + 1))
+        next_arg="${!i}"
+        # Check if the next argument is another option (starts with --)
+        if [[ "$next_arg" == --* ]]; then
+            echo 'Error: --short-name requires a value' >&2
+            exit 1
+        fi
+        SHORT_NAME="$next_arg"
+        ;;
+    --number)
+        if [ $((i + 1)) -gt $# ]; then
+            echo 'Error: --number requires a value' >&2
+            exit 1
+        fi
+        i=$((i + 1))
+        next_arg="${!i}"
+        if [[ "$next_arg" == --* ]]; then
+            echo 'Error: --number requires a value' >&2
+            exit 1
+        fi
+        BRANCH_NUMBER="$next_arg"
+        ;;
+    --help | -h)
+        echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
+        echo ""
+        echo "Options:"
+        echo "  --json              Output in JSON format"
+        echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+        echo "  --number N          Specify branch number manually (overrides auto-detection)"
+        echo "  --help, -h          Show this help message"
+        echo ""
+        echo "Examples:"
+        echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+        echo "  $0 'Implement OAuth2 integration for API' --number 5"
+        exit 0
+        ;;
+    *)
+        ARGS+=("$arg")
+        ;;
     esac
     i=$((i + 1))
 done
@@ -91,7 +91,7 @@ find_repo_root() {
 get_highest_from_specs() {
     local specs_dir="$1"
     local highest=0
-    
+
     if [ -d "$specs_dir" ]; then
         for dir in "$specs_dir"/*; do
             [ -d "$dir" ] || continue
@@ -103,22 +103,22 @@ get_highest_from_specs() {
             fi
         done
     fi
-    
+
     echo "$highest"
 }
 
 # Function to get highest number from git branches
 get_highest_from_branches() {
     local highest=0
-    
+
     # Get all branches (local and remote)
     branches=$(git branch -a 2>/dev/null || echo "")
-    
+
     if [ -n "$branches" ]; then
         while IFS= read -r branch; do
             # Clean branch name: remove leading markers and remote prefixes
             clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
-            
+
             # Extract feature number if branch matches pattern ###-*
             if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
                 number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
@@ -127,9 +127,9 @@ get_highest_from_branches() {
                     highest=$number
                 fi
             fi
-        done <<< "$branches"
+        done <<<"$branches"
     fi
-    
+
     echo "$highest"
 }
 
@@ -199,19 +199,19 @@ mkdir -p "$SPECS_DIR"
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
     local description="$1"
-    
+
     # Common stop words to filter out
     local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
-    
+
     # Convert to lowercase and split into words
     local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
-    
+
     # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
     local meaningful_words=()
     for word in $clean_name; do
         # Skip empty words
         [ -z "$word" ] && continue
-        
+
         # Keep words that are NOT stop words AND (length >= 3 OR are potential acronyms)
         if ! echo "$word" | grep -qiE "$stop_words"; then
             if [ ${#word} -ge 3 ]; then
@@ -222,12 +222,12 @@ generate_branch_name() {
             fi
         fi
     done
-    
+
     # If we have meaningful words, use first 3-4 of them
     if [ ${#meaningful_words[@]} -gt 0 ]; then
         local max_words=3
         if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
-        
+
         local result=""
         local count=0
         for word in "${meaningful_words[@]}"; do
@@ -276,15 +276,15 @@ if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
     # Calculate how much we need to trim from suffix
     # Account for: feature number (3) + hyphen (1) = 4 chars
     MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
-    
+
     # Truncate suffix at word boundary if possible
     TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
     # Remove trailing hyphen if truncation created one
     TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
-    
+
     ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
     BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
-    
+
     >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
     >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
     >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"

--- a/.specify/scripts/bash/create-new-feature.sh
+++ b/.specify/scripts/bash/create-new-feature.sh
@@ -8,168 +8,187 @@ BRANCH_NUMBER=""
 ARGS=()
 i=1
 while [ $i -le $# ]; do
-  arg="${!i}"
-  case "$arg" in
-    --json)
-      JSON_MODE=true
-      ;;
-    --short-name)
-      if [ $((i + 1)) -gt $# ]; then
-        echo 'Error: --short-name requires a value' >&2
-        exit 1
-      fi
-      i=$((i + 1))
-      next_arg="${!i}"
-      # Check if the next argument is another option (starts with --)
-      if [[ "$next_arg" == --* ]]; then
-        echo 'Error: --short-name requires a value' >&2
-        exit 1
-      fi
-      SHORT_NAME="$next_arg"
-      ;;
-    --number)
-      if [ $((i + 1)) -gt $# ]; then
-        echo 'Error: --number requires a value' >&2
-        exit 1
-      fi
-      i=$((i + 1))
-      next_arg="${!i}"
-      if [[ "$next_arg" == --* ]]; then
-        echo 'Error: --number requires a value' >&2
-        exit 1
-      fi
-      BRANCH_NUMBER="$next_arg"
-      ;;
-    --help | -h)
-      echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
-      echo ""
-      echo "Options:"
-      echo "  --json              Output in JSON format"
-      echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
-      echo "  --number N          Specify branch number manually (overrides auto-detection)"
-      echo "  --help, -h          Show this help message"
-      echo ""
-      echo "Examples:"
-      echo "  $0 'Add user authentication system' --short-name 'user-auth'"
-      echo "  $0 'Implement OAuth2 integration for API' --number 5"
-      exit 0
-      ;;
-    *)
-      ARGS+=("$arg")
-      ;;
-  esac
-  i=$((i + 1))
+    arg="${!i}"
+    case "$arg" in
+        --json) 
+            JSON_MODE=true 
+            ;;
+        --short-name)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            # Check if the next argument is another option (starts with --)
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --short-name requires a value' >&2
+                exit 1
+            fi
+            SHORT_NAME="$next_arg"
+            ;;
+        --number)
+            if [ $((i + 1)) -gt $# ]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            i=$((i + 1))
+            next_arg="${!i}"
+            if [[ "$next_arg" == --* ]]; then
+                echo 'Error: --number requires a value' >&2
+                exit 1
+            fi
+            BRANCH_NUMBER="$next_arg"
+            ;;
+        --help|-h) 
+            echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>"
+            echo ""
+            echo "Options:"
+            echo "  --json              Output in JSON format"
+            echo "  --short-name <name> Provide a custom short name (2-4 words) for the branch"
+            echo "  --number N          Specify branch number manually (overrides auto-detection)"
+            echo "  --help, -h          Show this help message"
+            echo ""
+            echo "Examples:"
+            echo "  $0 'Add user authentication system' --short-name 'user-auth'"
+            echo "  $0 'Implement OAuth2 integration for API' --number 5"
+            exit 0
+            ;;
+        *) 
+            ARGS+=("$arg") 
+            ;;
+    esac
+    i=$((i + 1))
 done
 
 FEATURE_DESCRIPTION="${ARGS[*]}"
 if [ -z "$FEATURE_DESCRIPTION" ]; then
-  echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>" >&2
-  exit 1
+    echo "Usage: $0 [--json] [--short-name <name>] [--number N] <feature_description>" >&2
+    exit 1
+fi
+
+# Trim whitespace and validate description is not empty (e.g., user passed only whitespace)
+FEATURE_DESCRIPTION=$(echo "$FEATURE_DESCRIPTION" | xargs)
+if [ -z "$FEATURE_DESCRIPTION" ]; then
+    echo "Error: Feature description cannot be empty or contain only whitespace" >&2
+    exit 1
 fi
 
 # Function to find the repository root by searching for existing project markers
 find_repo_root() {
-  local dir="$1"
-  while [ "$dir" != "/" ]; do
-    if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
-      echo "$dir"
-      return 0
-    fi
-    dir="$(dirname "$dir")"
-  done
-  return 1
+    local dir="$1"
+    while [ "$dir" != "/" ]; do
+        if [ -d "$dir/.git" ] || [ -d "$dir/.specify" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    return 1
 }
 
 # Function to get highest number from specs directory
 get_highest_from_specs() {
-  local specs_dir="$1"
-  local highest=0
-
-  if [ -d "$specs_dir" ]; then
-    for dir in "$specs_dir"/*; do
-      [ -d "$dir" ] || continue
-      dirname=$(basename "$dir")
-      number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
-      number=$((10#$number))
-      if [ "$number" -gt "$highest" ]; then
-        highest=$number
-      fi
-    done
-  fi
-
-  echo "$highest"
+    local specs_dir="$1"
+    local highest=0
+    
+    if [ -d "$specs_dir" ]; then
+        for dir in "$specs_dir"/*; do
+            [ -d "$dir" ] || continue
+            dirname=$(basename "$dir")
+            number=$(echo "$dirname" | grep -o '^[0-9]\+' || echo "0")
+            number=$((10#$number))
+            if [ "$number" -gt "$highest" ]; then
+                highest=$number
+            fi
+        done
+    fi
+    
+    echo "$highest"
 }
 
 # Function to get highest number from git branches
 get_highest_from_branches() {
-  local highest=0
-
-  # Get all branches (local and remote)
-  branches=$(git branch -a 2>/dev/null || echo "")
-
-  if [ -n "$branches" ]; then
-    while IFS= read -r branch; do
-      # Clean branch name: remove leading markers and remote prefixes
-      clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
-
-      # Extract feature number if branch matches pattern ###-*
-      if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
-        number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
-        number=$((10#$number))
-        if [ "$number" -gt "$highest" ]; then
-          highest=$number
-        fi
-      fi
-    done <<<"$branches"
-  fi
-
-  echo "$highest"
+    local highest=0
+    
+    # Get all branches (local and remote)
+    branches=$(git branch -a 2>/dev/null || echo "")
+    
+    if [ -n "$branches" ]; then
+        while IFS= read -r branch; do
+            # Clean branch name: remove leading markers and remote prefixes
+            clean_branch=$(echo "$branch" | sed 's/^[* ]*//; s|^remotes/[^/]*/||')
+            
+            # Extract feature number if branch matches pattern ###-*
+            if echo "$clean_branch" | grep -q '^[0-9]\{3\}-'; then
+                number=$(echo "$clean_branch" | grep -o '^[0-9]\{3\}' || echo "0")
+                number=$((10#$number))
+                if [ "$number" -gt "$highest" ]; then
+                    highest=$number
+                fi
+            fi
+        done <<< "$branches"
+    fi
+    
+    echo "$highest"
 }
 
 # Function to check existing branches (local and remote) and return next available number
 check_existing_branches() {
-  local specs_dir="$1"
+    local specs_dir="$1"
 
-  # Fetch all remotes to get latest branch info (suppress errors if no remotes)
-  git fetch --all --prune 2>/dev/null || true
+    # Fetch all remotes to get latest branch info (suppress errors if no remotes)
+    git fetch --all --prune 2>/dev/null || true
 
-  # Get highest number from ALL branches (not just matching short name)
-  local highest_branch=$(get_highest_from_branches)
+    # Get highest number from ALL branches (not just matching short name)
+    local highest_branch=$(get_highest_from_branches)
 
-  # Get highest number from ALL specs (not just matching short name)
-  local highest_spec=$(get_highest_from_specs "$specs_dir")
+    # Get highest number from ALL specs (not just matching short name)
+    local highest_spec=$(get_highest_from_specs "$specs_dir")
 
-  # Take the maximum of both
-  local max_num=$highest_branch
-  if [ "$highest_spec" -gt "$max_num" ]; then
-    max_num=$highest_spec
-  fi
+    # Take the maximum of both
+    local max_num=$highest_branch
+    if [ "$highest_spec" -gt "$max_num" ]; then
+        max_num=$highest_spec
+    fi
 
-  # Return next number
-  echo $((max_num + 1))
+    # Return next number
+    echo $((max_num + 1))
 }
 
 # Function to clean and format a branch name
 clean_branch_name() {
-  local name="$1"
-  echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
+    local name="$1"
+    echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/-\+/-/g' | sed 's/^-//' | sed 's/-$//'
+}
+
+# Escape a string for safe embedding in a JSON value (fallback when jq is unavailable).
+json_escape() {
+    local s="$1"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    s="${s//$'\n'/\\n}"
+    s="${s//$'\t'/\\t}"
+    s="${s//$'\r'/\\r}"
+    printf '%s' "$s"
 }
 
 # Resolve repository root. Prefer git information when available, but fall back
 # to searching for repository markers so the workflow still functions in repositories that
 # were initialised with --no-git.
 SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 if git rev-parse --show-toplevel >/dev/null 2>&1; then
-  REPO_ROOT=$(git rev-parse --show-toplevel)
-  HAS_GIT=true
+    REPO_ROOT=$(git rev-parse --show-toplevel)
+    HAS_GIT=true
 else
-  REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
-  if [ -z "$REPO_ROOT" ]; then
-    echo "Error: Could not determine repository root. Please run this script from within the repository." >&2
-    exit 1
-  fi
-  HAS_GIT=false
+    REPO_ROOT="$(find_repo_root "$SCRIPT_DIR")"
+    if [ -z "$REPO_ROOT" ]; then
+        echo "Error: Could not determine repository root. Please run this script from within the repository." >&2
+        exit 1
+    fi
+    HAS_GIT=false
 fi
 
 cd "$REPO_ROOT"
@@ -179,71 +198,71 @@ mkdir -p "$SPECS_DIR"
 
 # Function to generate branch name with stop word filtering and length filtering
 generate_branch_name() {
-  local description="$1"
-
-  # Common stop words to filter out
-  local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
-
-  # Convert to lowercase and split into words
-  local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
-
-  # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
-  local meaningful_words=()
-  for word in $clean_name; do
-    # Skip empty words
-    [ -z "$word" ] && continue
-
-    # Keep words that are NOT stop words AND (length >= 3 OR are potential acronyms)
-    if ! echo "$word" | grep -qiE "$stop_words"; then
-      if [ ${#word} -ge 3 ]; then
-        meaningful_words+=("$word")
-      elif echo "$description" | grep -q "\b${word^^}\b"; then
-        # Keep short words if they appear as uppercase in original (likely acronyms)
-        meaningful_words+=("$word")
-      fi
-    fi
-  done
-
-  # If we have meaningful words, use first 3-4 of them
-  if [ ${#meaningful_words[@]} -gt 0 ]; then
-    local max_words=3
-    if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
-
-    local result=""
-    local count=0
-    for word in "${meaningful_words[@]}"; do
-      if [ $count -ge $max_words ]; then break; fi
-      if [ -n "$result" ]; then result="$result-"; fi
-      result="$result$word"
-      count=$((count + 1))
+    local description="$1"
+    
+    # Common stop words to filter out
+    local stop_words="^(i|a|an|the|to|for|of|in|on|at|by|with|from|is|are|was|were|be|been|being|have|has|had|do|does|did|will|would|should|could|can|may|might|must|shall|this|that|these|those|my|your|our|their|want|need|add|get|set)$"
+    
+    # Convert to lowercase and split into words
+    local clean_name=$(echo "$description" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/ /g')
+    
+    # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
+    local meaningful_words=()
+    for word in $clean_name; do
+        # Skip empty words
+        [ -z "$word" ] && continue
+        
+        # Keep words that are NOT stop words AND (length >= 3 OR are potential acronyms)
+        if ! echo "$word" | grep -qiE "$stop_words"; then
+            if [ ${#word} -ge 3 ]; then
+                meaningful_words+=("$word")
+            elif echo "$description" | grep -q "\b${word^^}\b"; then
+                # Keep short words if they appear as uppercase in original (likely acronyms)
+                meaningful_words+=("$word")
+            fi
+        fi
     done
-    echo "$result"
-  else
-    # Fallback to original logic if no meaningful words found
-    local cleaned=$(clean_branch_name "$description")
-    echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
-  fi
+    
+    # If we have meaningful words, use first 3-4 of them
+    if [ ${#meaningful_words[@]} -gt 0 ]; then
+        local max_words=3
+        if [ ${#meaningful_words[@]} -eq 4 ]; then max_words=4; fi
+        
+        local result=""
+        local count=0
+        for word in "${meaningful_words[@]}"; do
+            if [ $count -ge $max_words ]; then break; fi
+            if [ -n "$result" ]; then result="$result-"; fi
+            result="$result$word"
+            count=$((count + 1))
+        done
+        echo "$result"
+    else
+        # Fallback to original logic if no meaningful words found
+        local cleaned=$(clean_branch_name "$description")
+        echo "$cleaned" | tr '-' '\n' | grep -v '^$' | head -3 | tr '\n' '-' | sed 's/-$//'
+    fi
 }
 
 # Generate branch name
 if [ -n "$SHORT_NAME" ]; then
-  # Use provided short name, just clean it up
-  BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
+    # Use provided short name, just clean it up
+    BRANCH_SUFFIX=$(clean_branch_name "$SHORT_NAME")
 else
-  # Generate from description with smart filtering
-  BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
+    # Generate from description with smart filtering
+    BRANCH_SUFFIX=$(generate_branch_name "$FEATURE_DESCRIPTION")
 fi
 
 # Determine branch number
 if [ -z "$BRANCH_NUMBER" ]; then
-  if [ "$HAS_GIT" = true ]; then
-    # Check existing branches on remotes
-    BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
-  else
-    # Fall back to local directory check
-    HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
-    BRANCH_NUMBER=$((HIGHEST + 1))
-  fi
+    if [ "$HAS_GIT" = true ]; then
+        # Check existing branches on remotes
+        BRANCH_NUMBER=$(check_existing_branches "$SPECS_DIR")
+    else
+        # Fall back to local directory check
+        HIGHEST=$(get_highest_from_specs "$SPECS_DIR")
+        BRANCH_NUMBER=$((HIGHEST + 1))
+    fi
 fi
 
 # Force base-10 interpretation to prevent octal conversion (e.g., 010 → 8 in octal, but should be 10 in decimal)
@@ -254,44 +273,61 @@ BRANCH_NAME="${FEATURE_NUM}-${BRANCH_SUFFIX}"
 # Validate and truncate if necessary
 MAX_BRANCH_LENGTH=244
 if [ ${#BRANCH_NAME} -gt $MAX_BRANCH_LENGTH ]; then
-  # Calculate how much we need to trim from suffix
-  # Account for: feature number (3) + hyphen (1) = 4 chars
-  MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
-
-  # Truncate suffix at word boundary if possible
-  TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
-  # Remove trailing hyphen if truncation created one
-  TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
-
-  ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
-  BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
-
-  >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
-  >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
-  >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
+    # Calculate how much we need to trim from suffix
+    # Account for: feature number (3) + hyphen (1) = 4 chars
+    MAX_SUFFIX_LENGTH=$((MAX_BRANCH_LENGTH - 4))
+    
+    # Truncate suffix at word boundary if possible
+    TRUNCATED_SUFFIX=$(echo "$BRANCH_SUFFIX" | cut -c1-$MAX_SUFFIX_LENGTH)
+    # Remove trailing hyphen if truncation created one
+    TRUNCATED_SUFFIX=$(echo "$TRUNCATED_SUFFIX" | sed 's/-$//')
+    
+    ORIGINAL_BRANCH_NAME="$BRANCH_NAME"
+    BRANCH_NAME="${FEATURE_NUM}-${TRUNCATED_SUFFIX}"
+    
+    >&2 echo "[specify] Warning: Branch name exceeded GitHub's 244-byte limit"
+    >&2 echo "[specify] Original: $ORIGINAL_BRANCH_NAME (${#ORIGINAL_BRANCH_NAME} bytes)"
+    >&2 echo "[specify] Truncated to: $BRANCH_NAME (${#BRANCH_NAME} bytes)"
 fi
 
 if [ "$HAS_GIT" = true ]; then
-  git checkout -b "$BRANCH_NAME"
+    if ! git checkout -b "$BRANCH_NAME" 2>/dev/null; then
+        # Check if branch already exists
+        if git branch --list "$BRANCH_NAME" | grep -q .; then
+            >&2 echo "Error: Branch '$BRANCH_NAME' already exists. Please use a different feature name or specify a different number with --number."
+            exit 1
+        else
+            >&2 echo "Error: Failed to create git branch '$BRANCH_NAME'. Please check your git configuration and try again."
+            exit 1
+        fi
+    fi
 else
-  >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
+    >&2 echo "[specify] Warning: Git repository not detected; skipped branch creation for $BRANCH_NAME"
 fi
 
 FEATURE_DIR="$SPECS_DIR/$BRANCH_NAME"
 mkdir -p "$FEATURE_DIR"
 
-TEMPLATE="$REPO_ROOT/.specify/templates/spec-template.md"
+TEMPLATE=$(resolve_template "spec-template" "$REPO_ROOT")
 SPEC_FILE="$FEATURE_DIR/spec.md"
-if [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
+if [ -n "$TEMPLATE" ] && [ -f "$TEMPLATE" ]; then cp "$TEMPLATE" "$SPEC_FILE"; else touch "$SPEC_FILE"; fi
 
-# Set the SPECIFY_FEATURE environment variable for the current session
-export SPECIFY_FEATURE="$BRANCH_NAME"
+# Inform the user how to persist the feature variable in their own shell
+printf '# To persist: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME" >&2
 
 if $JSON_MODE; then
-  printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$BRANCH_NAME" "$SPEC_FILE" "$FEATURE_NUM"
+    if command -v jq >/dev/null 2>&1; then
+        jq -cn \
+            --arg branch_name "$BRANCH_NAME" \
+            --arg spec_file "$SPEC_FILE" \
+            --arg feature_num "$FEATURE_NUM" \
+            '{BRANCH_NAME:$branch_name,SPEC_FILE:$spec_file,FEATURE_NUM:$feature_num}'
+    else
+        printf '{"BRANCH_NAME":"%s","SPEC_FILE":"%s","FEATURE_NUM":"%s"}\n' "$(json_escape "$BRANCH_NAME")" "$(json_escape "$SPEC_FILE")" "$(json_escape "$FEATURE_NUM")"
+    fi
 else
-  echo "BRANCH_NAME: $BRANCH_NAME"
-  echo "SPEC_FILE: $SPEC_FILE"
-  echo "FEATURE_NUM: $FEATURE_NUM"
-  echo "SPECIFY_FEATURE environment variable set to: $BRANCH_NAME"
+    echo "BRANCH_NAME: $BRANCH_NAME"
+    echo "SPEC_FILE: $SPEC_FILE"
+    echo "FEATURE_NUM: $FEATURE_NUM"
+    printf '# To persist in your shell: export SPECIFY_FEATURE=%q\n' "$BRANCH_NAME"
 fi

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -8,18 +8,18 @@ ARGS=()
 
 for arg in "$@"; do
     case "$arg" in
-        --json) 
-            JSON_MODE=true 
-            ;;
-        --help|-h) 
-            echo "Usage: $0 [--json]"
-            echo "  --json    Output results in JSON format"
-            echo "  --help    Show this help message"
-            exit 0 
-            ;;
-        *) 
-            ARGS+=("$arg") 
-            ;;
+    --json)
+        JSON_MODE=true
+        ;;
+    --help | -h)
+        echo "Usage: $0 [--json]"
+        echo "  --json    Output results in JSON format"
+        echo "  --help    Show this help message"
+        exit 0
+        ;;
+    *)
+        ARGS+=("$arg")
+        ;;
     esac
 done
 
@@ -28,7 +28,10 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+_paths_output=$(get_feature_paths) || {
+    echo "ERROR: Failed to resolve feature paths" >&2
+    exit 1
+}
 eval "$_paths_output"
 unset _paths_output
 
@@ -65,9 +68,8 @@ if $JSON_MODE; then
     fi
 else
     echo "FEATURE_SPEC: $FEATURE_SPEC"
-    echo "IMPL_PLAN: $IMPL_PLAN" 
+    echo "IMPL_PLAN: $IMPL_PLAN"
     echo "SPECS_DIR: $FEATURE_DIR"
     echo "BRANCH: $CURRENT_BRANCH"
     echo "HAS_GIT: $HAS_GIT"
 fi
-

--- a/.specify/scripts/bash/setup-plan.sh
+++ b/.specify/scripts/bash/setup-plan.sh
@@ -7,20 +7,20 @@ JSON_MODE=false
 ARGS=()
 
 for arg in "$@"; do
-  case "$arg" in
-    --json)
-      JSON_MODE=true
-      ;;
-    --help | -h)
-      echo "Usage: $0 [--json]"
-      echo "  --json    Output results in JSON format"
-      echo "  --help    Show this help message"
-      exit 0
-      ;;
-    *)
-      ARGS+=("$arg")
-      ;;
-  esac
+    case "$arg" in
+        --json) 
+            JSON_MODE=true 
+            ;;
+        --help|-h) 
+            echo "Usage: $0 [--json]"
+            echo "  --json    Output results in JSON format"
+            echo "  --help    Show this help message"
+            exit 0 
+            ;;
+        *) 
+            ARGS+=("$arg") 
+            ;;
+    esac
 done
 
 # Get script directory and load common functions
@@ -28,7 +28,9 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
 # Check if we're on a proper feature branch (only for git repos)
 check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
@@ -37,24 +39,35 @@ check_feature_branch "$CURRENT_BRANCH" "$HAS_GIT" || exit 1
 mkdir -p "$FEATURE_DIR"
 
 # Copy plan template if it exists
-TEMPLATE="$REPO_ROOT/.specify/templates/plan-template.md"
-if [[ -f "$TEMPLATE" ]]; then
-  cp "$TEMPLATE" "$IMPL_PLAN"
-  echo "Copied plan template to $IMPL_PLAN"
+TEMPLATE=$(resolve_template "plan-template" "$REPO_ROOT")
+if [[ -n "$TEMPLATE" ]] && [[ -f "$TEMPLATE" ]]; then
+    cp "$TEMPLATE" "$IMPL_PLAN"
+    echo "Copied plan template to $IMPL_PLAN"
 else
-  echo "Warning: Plan template not found at $TEMPLATE"
-  # Create a basic plan file if template doesn't exist
-  touch "$IMPL_PLAN"
+    echo "Warning: Plan template not found"
+    # Create a basic plan file if template doesn't exist
+    touch "$IMPL_PLAN"
 fi
 
 # Output results
 if $JSON_MODE; then
-  printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
-    "$FEATURE_SPEC" "$IMPL_PLAN" "$FEATURE_DIR" "$CURRENT_BRANCH" "$HAS_GIT"
+    if has_jq; then
+        jq -cn \
+            --arg feature_spec "$FEATURE_SPEC" \
+            --arg impl_plan "$IMPL_PLAN" \
+            --arg specs_dir "$FEATURE_DIR" \
+            --arg branch "$CURRENT_BRANCH" \
+            --arg has_git "$HAS_GIT" \
+            '{FEATURE_SPEC:$feature_spec,IMPL_PLAN:$impl_plan,SPECS_DIR:$specs_dir,BRANCH:$branch,HAS_GIT:$has_git}'
+    else
+        printf '{"FEATURE_SPEC":"%s","IMPL_PLAN":"%s","SPECS_DIR":"%s","BRANCH":"%s","HAS_GIT":"%s"}\n' \
+            "$(json_escape "$FEATURE_SPEC")" "$(json_escape "$IMPL_PLAN")" "$(json_escape "$FEATURE_DIR")" "$(json_escape "$CURRENT_BRANCH")" "$(json_escape "$HAS_GIT")"
+    fi
 else
-  echo "FEATURE_SPEC: $FEATURE_SPEC"
-  echo "IMPL_PLAN: $IMPL_PLAN"
-  echo "SPECS_DIR: $FEATURE_DIR"
-  echo "BRANCH: $CURRENT_BRANCH"
-  echo "HAS_GIT: $HAS_GIT"
+    echo "FEATURE_SPEC: $FEATURE_SPEC"
+    echo "IMPL_PLAN: $IMPL_PLAN" 
+    echo "SPECS_DIR: $FEATURE_DIR"
+    echo "BRANCH: $CURRENT_BRANCH"
+    echo "HAS_GIT: $HAS_GIT"
 fi
+

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -2,7 +2,7 @@
 
 # Update agent context files with information from plan.md
 #
-# This script maintains AI agent context files by parsing feature specifications 
+# This script maintains AI agent context files by parsing feature specifications
 # and updating agent-specific configuration files with project information.
 #
 # MAIN FUNCTIONS:
@@ -53,14 +53,17 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+_paths_output=$(get_feature_paths) || {
+    echo "ERROR: Failed to resolve feature paths" >&2
+    exit 1
+}
 eval "$_paths_output"
 unset _paths_output
 
-NEW_PLAN="$IMPL_PLAN"  # Alias for compatibility with existing code
+NEW_PLAN="$IMPL_PLAN" # Alias for compatibility with existing code
 AGENT_TYPE="${1:-}"
 
-# Agent-specific file paths  
+# Agent-specific file paths
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
 COPILOT_FILE="$REPO_ROOT/.github/agents/copilot-instructions.md"
@@ -141,7 +144,7 @@ validate_environment() {
         fi
         exit 1
     fi
-    
+
     # Check if plan.md exists
     if [[ ! -f "$NEW_PLAN" ]]; then
         log_error "No plan.md found at $NEW_PLAN"
@@ -151,7 +154,7 @@ validate_environment() {
         fi
         exit 1
     fi
-    
+
     # Check if template exists (needed for new files)
     if [[ ! -f "$TEMPLATE_FILE" ]]; then
         log_warning "Template file not found at $TEMPLATE_FILE"
@@ -166,50 +169,50 @@ validate_environment() {
 extract_plan_field() {
     local field_pattern="$1"
     local plan_file="$2"
-    
-    grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null | \
-        head -1 | \
-        sed "s|^\*\*${field_pattern}\*\*: ||" | \
-        sed 's/^[ \t]*//;s/[ \t]*$//' | \
-        grep -v "NEEDS CLARIFICATION" | \
+
+    grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null |
+        head -1 |
+        sed "s|^\*\*${field_pattern}\*\*: ||" |
+        sed 's/^[ \t]*//;s/[ \t]*$//' |
+        grep -v "NEEDS CLARIFICATION" |
         grep -v "^N/A$" || echo ""
 }
 
 parse_plan_data() {
     local plan_file="$1"
-    
+
     if [[ ! -f "$plan_file" ]]; then
         log_error "Plan file not found: $plan_file"
         return 1
     fi
-    
+
     if [[ ! -r "$plan_file" ]]; then
         log_error "Plan file is not readable: $plan_file"
         return 1
     fi
-    
+
     log_info "Parsing plan data from $plan_file"
-    
+
     NEW_LANG=$(extract_plan_field "Language/Version" "$plan_file")
     NEW_FRAMEWORK=$(extract_plan_field "Primary Dependencies" "$plan_file")
     NEW_DB=$(extract_plan_field "Storage" "$plan_file")
     NEW_PROJECT_TYPE=$(extract_plan_field "Project Type" "$plan_file")
-    
+
     # Log what we found
     if [[ -n "$NEW_LANG" ]]; then
         log_info "Found language: $NEW_LANG"
     else
         log_warning "No language information found in plan"
     fi
-    
+
     if [[ -n "$NEW_FRAMEWORK" ]]; then
         log_info "Found framework: $NEW_FRAMEWORK"
     fi
-    
+
     if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
         log_info "Found database: $NEW_DB"
     fi
-    
+
     if [[ -n "$NEW_PROJECT_TYPE" ]]; then
         log_info "Found project type: $NEW_PROJECT_TYPE"
     fi
@@ -219,11 +222,11 @@ format_technology_stack() {
     local lang="$1"
     local framework="$2"
     local parts=()
-    
+
     # Add non-empty parts
     [[ -n "$lang" && "$lang" != "NEEDS CLARIFICATION" ]] && parts+=("$lang")
     [[ -n "$framework" && "$framework" != "NEEDS CLARIFICATION" && "$framework" != "N/A" ]] && parts+=("$framework")
-    
+
     # Join with proper formatting
     if [[ ${#parts[@]} -eq 0 ]]; then
         echo ""
@@ -232,7 +235,7 @@ format_technology_stack() {
     else
         # Join multiple parts with " + "
         local result="${parts[0]}"
-        for ((i=1; i<${#parts[@]}; i++)); do
+        for ((i = 1; i < ${#parts[@]}; i++)); do
             result="$result + ${parts[i]}"
         done
         echo "$result"
@@ -245,7 +248,7 @@ format_technology_stack() {
 
 get_project_structure() {
     local project_type="$1"
-    
+
     if [[ "$project_type" == *"web"* ]]; then
         echo "backend/\\nfrontend/\\ntests/"
     else
@@ -255,20 +258,20 @@ get_project_structure() {
 
 get_commands_for_language() {
     local lang="$1"
-    
+
     case "$lang" in
-        *"Python"*)
-            echo "cd src && pytest && ruff check ."
-            ;;
-        *"Rust"*)
-            echo "cargo test && cargo clippy"
-            ;;
-        *"JavaScript"*|*"TypeScript"*)
-            echo "npm test \\&\\& npm run lint"
-            ;;
-        *)
-            echo "# Add commands for $lang"
-            ;;
+    *"Python"*)
+        echo "cd src && pytest && ruff check ."
+        ;;
+    *"Rust"*)
+        echo "cargo test && cargo clippy"
+        ;;
+    *"JavaScript"* | *"TypeScript"*)
+        echo "npm test \\&\\& npm run lint"
+        ;;
+    *)
+        echo "# Add commands for $lang"
+        ;;
     esac
 }
 
@@ -282,40 +285,40 @@ create_new_agent_file() {
     local temp_file="$2"
     local project_name="$3"
     local current_date="$4"
-    
+
     if [[ ! -f "$TEMPLATE_FILE" ]]; then
         log_error "Template not found at $TEMPLATE_FILE"
         return 1
     fi
-    
+
     if [[ ! -r "$TEMPLATE_FILE" ]]; then
         log_error "Template file is not readable: $TEMPLATE_FILE"
         return 1
     fi
-    
+
     log_info "Creating new agent context file from template..."
-    
+
     if ! cp "$TEMPLATE_FILE" "$temp_file"; then
         log_error "Failed to copy template file"
         return 1
     fi
-    
+
     # Replace template placeholders
     local project_structure
     project_structure=$(get_project_structure "$NEW_PROJECT_TYPE")
-    
+
     local commands
     commands=$(get_commands_for_language "$NEW_LANG")
-    
+
     local language_conventions
     language_conventions=$(get_language_conventions "$NEW_LANG")
-    
+
     # Perform substitutions with error checking using safer approach
     # Escape special characters for sed by using a different delimiter or escaping
     local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
     local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
     local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-    
+
     # Build technology stack and recent change strings conditionally
     local tech_stack
     if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
@@ -348,7 +351,7 @@ create_new_agent_file() {
         "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
         "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
     )
-    
+
     for substitution in "${substitutions[@]}"; do
         if ! sed -i.bak -e "$substitution" "$temp_file"; then
             log_error "Failed to perform substitution: $substitution"
@@ -356,7 +359,7 @@ create_new_agent_file() {
             return 1
         fi
     done
-    
+
     # Convert \n sequences to actual newlines
     newline=$(printf '\n')
     sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
@@ -368,63 +371,60 @@ create_new_agent_file() {
     if [[ "$target_file" == *.mdc ]]; then
         local frontmatter_file
         frontmatter_file=$(mktemp) || return 1
-        printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
-        cat "$temp_file" >> "$frontmatter_file"
+        printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" >"$frontmatter_file"
+        cat "$temp_file" >>"$frontmatter_file"
         mv "$frontmatter_file" "$temp_file"
     fi
 
     return 0
 }
 
-
-
-
 update_existing_agent_file() {
     local target_file="$1"
     local current_date="$2"
-    
+
     log_info "Updating existing agent context file..."
-    
+
     # Use a single temporary file for atomic update
     local temp_file
     temp_file=$(mktemp) || {
         log_error "Failed to create temporary file"
         return 1
     }
-    
+
     # Process the file in one pass
     local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
     local new_tech_entries=()
     local new_change_entry=""
-    
+
     # Prepare new technology entries
     if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
         new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
     fi
-    
+
     if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
         new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
     fi
-    
+
     # Prepare new change entry
     if [[ -n "$tech_stack" ]]; then
         new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
     elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
         new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
     fi
-    
+
     # Check if sections exist in the file
     local has_active_technologies=0
     local has_recent_changes=0
-    
+
     if grep -q "^## Active Technologies" "$target_file" 2>/dev/null; then
         has_active_technologies=1
     fi
-    
+
     if grep -q "^## Recent Changes" "$target_file" 2>/dev/null; then
         has_recent_changes=1
     fi
-    
+
     # Process file line by line
     local in_tech_section=false
     local in_changes_section=false
@@ -432,91 +432,94 @@ update_existing_agent_file() {
     local changes_entries_added=false
     local existing_changes_count=0
     local file_ended=false
-    
+
     while IFS= read -r line || [[ -n "$line" ]]; do
         # Handle Active Technologies section
         if [[ "$line" == "## Active Technologies" ]]; then
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
             in_tech_section=true
             continue
         elif [[ $in_tech_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
             # Add new tech entries before closing the section
             if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+                printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
                 tech_entries_added=true
             fi
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
             in_tech_section=false
             continue
         elif [[ $in_tech_section == true ]] && [[ -z "$line" ]]; then
             # Add new tech entries before empty line in tech section
             if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+                printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
                 tech_entries_added=true
             fi
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
             continue
         fi
-        
+
         # Handle Recent Changes section
         if [[ "$line" == "## Recent Changes" ]]; then
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
             # Add new change entry right after the heading
             if [[ -n "$new_change_entry" ]]; then
-                echo "$new_change_entry" >> "$temp_file"
+                echo "$new_change_entry" >>"$temp_file"
             fi
             in_changes_section=true
             changes_entries_added=true
             continue
         elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
             in_changes_section=false
             continue
         elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
             # Keep only first 2 existing changes
             if [[ $existing_changes_count -lt 2 ]]; then
-                echo "$line" >> "$temp_file"
+                echo "$line" >>"$temp_file"
                 ((existing_changes_count++))
             fi
             continue
         fi
-        
+
         # Update timestamp
         if [[ "$line" =~ (\*\*)?Last\ updated(\*\*)?:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
-            echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
+            echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >>"$temp_file"
         else
-            echo "$line" >> "$temp_file"
+            echo "$line" >>"$temp_file"
         fi
-    done < "$target_file"
-    
+    done <"$target_file"
+
     # Post-loop check: if we're still in the Active Technologies section and haven't added new entries
     if [[ $in_tech_section == true ]] && [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-        printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
         tech_entries_added=true
     fi
-    
+
     # If sections don't exist, add them at the end of the file
     if [[ $has_active_technologies -eq 0 ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-        echo "" >> "$temp_file"
-        echo "## Active Technologies" >> "$temp_file"
-        printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+        echo "" >>"$temp_file"
+        echo "## Active Technologies" >>"$temp_file"
+        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
         tech_entries_added=true
     fi
-    
+
     if [[ $has_recent_changes -eq 0 ]] && [[ -n "$new_change_entry" ]]; then
-        echo "" >> "$temp_file"
-        echo "## Recent Changes" >> "$temp_file"
-        echo "$new_change_entry" >> "$temp_file"
+        echo "" >>"$temp_file"
+        echo "## Recent Changes" >>"$temp_file"
+        echo "$new_change_entry" >>"$temp_file"
         changes_entries_added=true
     fi
-    
+
     # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
     if [[ "$target_file" == *.mdc ]]; then
         if ! head -1 "$temp_file" | grep -q '^---'; then
             local frontmatter_file
-            frontmatter_file=$(mktemp) || { rm -f "$temp_file"; return 1; }
-            printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
-            cat "$temp_file" >> "$frontmatter_file"
+            frontmatter_file=$(mktemp) || {
+                rm -f "$temp_file"
+                return 1
+            }
+            printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" >"$frontmatter_file"
+            cat "$temp_file" >>"$frontmatter_file"
             mv "$frontmatter_file" "$temp_file"
         fi
     fi
@@ -537,19 +540,19 @@ update_existing_agent_file() {
 update_agent_file() {
     local target_file="$1"
     local agent_name="$2"
-    
+
     if [[ -z "$target_file" ]] || [[ -z "$agent_name" ]]; then
         log_error "update_agent_file requires target_file and agent_name parameters"
         return 1
     fi
-    
+
     log_info "Updating $agent_name context file: $target_file"
-    
+
     local project_name
     project_name=$(basename "$REPO_ROOT")
     local current_date
     current_date=$(date +%Y-%m-%d)
-    
+
     # Create directory if it doesn't exist
     local target_dir
     target_dir=$(dirname "$target_file")
@@ -559,7 +562,7 @@ update_agent_file() {
             return 1
         fi
     fi
-    
+
     if [[ ! -f "$target_file" ]]; then
         # Create new file from template
         local temp_file
@@ -567,7 +570,7 @@ update_agent_file() {
             log_error "Failed to create temporary file"
             return 1
         }
-        
+
         if create_new_agent_file "$target_file" "$temp_file" "$project_name" "$current_date"; then
             if mv "$temp_file" "$target_file"; then
                 log_success "Created new $agent_name context file"
@@ -587,12 +590,12 @@ update_agent_file() {
             log_error "Cannot read existing file: $target_file"
             return 1
         fi
-        
+
         if [[ ! -w "$target_file" ]]; then
             log_error "Cannot write to existing file: $target_file"
             return 1
         fi
-        
+
         if update_existing_agent_file "$target_file" "$current_date"; then
             log_success "Updated existing $agent_name context file"
         else
@@ -600,7 +603,7 @@ update_agent_file() {
             return 1
         fi
     fi
-    
+
     return 0
 }
 
@@ -610,79 +613,79 @@ update_agent_file() {
 
 update_specific_agent() {
     local agent_type="$1"
-    
+
     case "$agent_type" in
-        claude)
-            update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
-            ;;
-        gemini)
-            update_agent_file "$GEMINI_FILE" "Gemini CLI" || return 1
-            ;;
-        copilot)
-            update_agent_file "$COPILOT_FILE" "GitHub Copilot" || return 1
-            ;;
-        cursor-agent)
-            update_agent_file "$CURSOR_FILE" "Cursor IDE" || return 1
-            ;;
-        qwen)
-            update_agent_file "$QWEN_FILE" "Qwen Code" || return 1
-            ;;
-        opencode)
-            update_agent_file "$AGENTS_FILE" "opencode" || return 1
-            ;;
-        codex)
-            update_agent_file "$AGENTS_FILE" "Codex CLI" || return 1
-            ;;
-        windsurf)
-            update_agent_file "$WINDSURF_FILE" "Windsurf" || return 1
-            ;;
-        kilocode)
-            update_agent_file "$KILOCODE_FILE" "Kilo Code" || return 1
-            ;;
-        auggie)
-            update_agent_file "$AUGGIE_FILE" "Auggie CLI" || return 1
-            ;;
-        roo)
-            update_agent_file "$ROO_FILE" "Roo Code" || return 1
-            ;;
-        codebuddy)
-            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI" || return 1
-            ;;
-        qodercli)
-            update_agent_file "$QODER_FILE" "Qoder CLI" || return 1
-            ;;
-        amp)
-            update_agent_file "$AMP_FILE" "Amp" || return 1
-            ;;
-        shai)
-            update_agent_file "$SHAI_FILE" "SHAI" || return 1
-            ;;
-        tabnine)
-            update_agent_file "$TABNINE_FILE" "Tabnine CLI" || return 1
-            ;;
-        kiro-cli)
-            update_agent_file "$KIRO_FILE" "Kiro CLI" || return 1
-            ;;
-        agy)
-            update_agent_file "$AGY_FILE" "Antigravity" || return 1
-            ;;
-        bob)
-            update_agent_file "$BOB_FILE" "IBM Bob" || return 1
-            ;;
-        vibe)
-            update_agent_file "$VIBE_FILE" "Mistral Vibe" || return 1
-            ;;
-        kimi)
-            update_agent_file "$KIMI_FILE" "Kimi Code" || return 1
-            ;;
-        generic)
-            log_info "Generic agent: no predefined context file. Use the agent-specific update script for your agent."
-            ;;
-        *)
-            log_error "Unknown agent type '$agent_type'"
-            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic"
-            exit 1
-            ;;
+    claude)
+        update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
+        ;;
+    gemini)
+        update_agent_file "$GEMINI_FILE" "Gemini CLI" || return 1
+        ;;
+    copilot)
+        update_agent_file "$COPILOT_FILE" "GitHub Copilot" || return 1
+        ;;
+    cursor-agent)
+        update_agent_file "$CURSOR_FILE" "Cursor IDE" || return 1
+        ;;
+    qwen)
+        update_agent_file "$QWEN_FILE" "Qwen Code" || return 1
+        ;;
+    opencode)
+        update_agent_file "$AGENTS_FILE" "opencode" || return 1
+        ;;
+    codex)
+        update_agent_file "$AGENTS_FILE" "Codex CLI" || return 1
+        ;;
+    windsurf)
+        update_agent_file "$WINDSURF_FILE" "Windsurf" || return 1
+        ;;
+    kilocode)
+        update_agent_file "$KILOCODE_FILE" "Kilo Code" || return 1
+        ;;
+    auggie)
+        update_agent_file "$AUGGIE_FILE" "Auggie CLI" || return 1
+        ;;
+    roo)
+        update_agent_file "$ROO_FILE" "Roo Code" || return 1
+        ;;
+    codebuddy)
+        update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI" || return 1
+        ;;
+    qodercli)
+        update_agent_file "$QODER_FILE" "Qoder CLI" || return 1
+        ;;
+    amp)
+        update_agent_file "$AMP_FILE" "Amp" || return 1
+        ;;
+    shai)
+        update_agent_file "$SHAI_FILE" "SHAI" || return 1
+        ;;
+    tabnine)
+        update_agent_file "$TABNINE_FILE" "Tabnine CLI" || return 1
+        ;;
+    kiro-cli)
+        update_agent_file "$KIRO_FILE" "Kiro CLI" || return 1
+        ;;
+    agy)
+        update_agent_file "$AGY_FILE" "Antigravity" || return 1
+        ;;
+    bob)
+        update_agent_file "$BOB_FILE" "IBM Bob" || return 1
+        ;;
+    vibe)
+        update_agent_file "$VIBE_FILE" "Mistral Vibe" || return 1
+        ;;
+    kimi)
+        update_agent_file "$KIMI_FILE" "Kimi Code" || return 1
+        ;;
+    generic)
+        log_info "Generic agent: no predefined context file. Use the agent-specific update script for your agent."
+        ;;
+    *)
+        log_error "Unknown agent type '$agent_type'"
+        log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic"
+        exit 1
+        ;;
     esac
 }
 
@@ -740,19 +743,19 @@ update_all_existing_agents() {
 print_summary() {
     echo
     log_info "Summary of changes:"
-    
+
     if [[ -n "$NEW_LANG" ]]; then
         echo "  - Added language: $NEW_LANG"
     fi
-    
+
     if [[ -n "$NEW_FRAMEWORK" ]]; then
         echo "  - Added framework: $NEW_FRAMEWORK"
     fi
-    
+
     if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
         echo "  - Added database: $NEW_DB"
     fi
-    
+
     echo
     log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic]"
 }
@@ -764,18 +767,18 @@ print_summary() {
 main() {
     # Validate environment before proceeding
     validate_environment
-    
+
     log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
-    
+
     # Parse the plan file to extract project information
     if ! parse_plan_data "$NEW_PLAN"; then
         log_error "Failed to parse plan data"
         exit 1
     fi
-    
+
     # Process based on agent type argument
     local success=true
-    
+
     if [[ -z "$AGENT_TYPE" ]]; then
         # No specific agent provided - update all existing agent files
         log_info "No agent specified, updating all existing agent files..."
@@ -789,10 +792,10 @@ main() {
             success=false
         fi
     fi
-    
+
     # Print summary
     print_summary
-    
+
     if [[ "$success" == true ]]; then
         log_success "Agent context update completed successfully"
         exit 0

--- a/.specify/scripts/bash/update-agent-context.sh
+++ b/.specify/scripts/bash/update-agent-context.sh
@@ -2,7 +2,7 @@
 
 # Update agent context files with information from plan.md
 #
-# This script maintains AI agent context files by parsing feature specifications
+# This script maintains AI agent context files by parsing feature specifications 
 # and updating agent-specific configuration files with project information.
 #
 # MAIN FUNCTIONS:
@@ -30,12 +30,12 @@
 #
 # 5. Multi-Agent Support
 #    - Handles agent-specific file paths and naming conventions
-#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, or Amazon Q Developer CLI
+#    - Supports: Claude, Gemini, Copilot, Cursor, Qwen, opencode, Codex, Windsurf, Kilo Code, Auggie CLI, Roo Code, CodeBuddy CLI, Qoder CLI, Amp, SHAI, Tabnine CLI, Kiro CLI, Mistral Vibe, Kimi Code, Antigravity or Generic
 #    - Can update single agents or all existing agent files
 #    - Creates default Claude file if no agent files exist
 #
 # Usage: ./update-agent-context.sh [agent_type]
-# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|shai|q|bob|qoder
+# Agent types: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic
 # Leave empty to update all existing agent files
 
 set -e
@@ -53,12 +53,14 @@ SCRIPT_DIR="$(CDPATH="" cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/common.sh"
 
 # Get all paths and variables from common functions
-eval $(get_feature_paths)
+_paths_output=$(get_feature_paths) || { echo "ERROR: Failed to resolve feature paths" >&2; exit 1; }
+eval "$_paths_output"
+unset _paths_output
 
-NEW_PLAN="$IMPL_PLAN" # Alias for compatibility with existing code
+NEW_PLAN="$IMPL_PLAN"  # Alias for compatibility with existing code
 AGENT_TYPE="${1:-}"
 
-# Agent-specific file paths
+# Agent-specific file paths  
 CLAUDE_FILE="$REPO_ROOT/CLAUDE.md"
 GEMINI_FILE="$REPO_ROOT/GEMINI.md"
 COPILOT_FILE="$REPO_ROOT/.github/agents/copilot-instructions.md"
@@ -71,10 +73,16 @@ AUGGIE_FILE="$REPO_ROOT/.augment/rules/specify-rules.md"
 ROO_FILE="$REPO_ROOT/.roo/rules/specify-rules.md"
 CODEBUDDY_FILE="$REPO_ROOT/CODEBUDDY.md"
 QODER_FILE="$REPO_ROOT/QODER.md"
-AMP_FILE="$REPO_ROOT/AGENTS.md"
+# AMP, Kiro CLI, and IBM Bob all share AGENTS.md — use AGENTS_FILE to avoid
+# updating the same file multiple times.
+AMP_FILE="$AGENTS_FILE"
 SHAI_FILE="$REPO_ROOT/SHAI.md"
-Q_FILE="$REPO_ROOT/AGENTS.md"
-BOB_FILE="$REPO_ROOT/AGENTS.md"
+TABNINE_FILE="$REPO_ROOT/TABNINE.md"
+KIRO_FILE="$AGENTS_FILE"
+AGY_FILE="$REPO_ROOT/.agent/rules/specify-rules.md"
+BOB_FILE="$AGENTS_FILE"
+VIBE_FILE="$REPO_ROOT/.vibe/agents/specify-agents.md"
+KIMI_FILE="$REPO_ROOT/KIMI.md"
 
 # Template file
 TEMPLATE_FILE="$REPO_ROOT/.specify/templates/agent-file-template.md"
@@ -90,27 +98,29 @@ NEW_PROJECT_TYPE=""
 #==============================================================================
 
 log_info() {
-  echo "INFO: $1"
+    echo "INFO: $1"
 }
 
 log_success() {
-  echo "✓ $1"
+    echo "✓ $1"
 }
 
 log_error() {
-  echo "ERROR: $1" >&2
+    echo "ERROR: $1" >&2
 }
 
 log_warning() {
-  echo "WARNING: $1" >&2
+    echo "WARNING: $1" >&2
 }
 
 # Cleanup function for temporary files
 cleanup() {
-  local exit_code=$?
-  rm -f /tmp/agent_update_*_$$
-  rm -f /tmp/manual_additions_$$
-  exit $exit_code
+    local exit_code=$?
+    # Disarm traps to prevent re-entrant loop
+    trap - EXIT INT TERM
+    rm -f /tmp/agent_update_*_$$
+    rm -f /tmp/manual_additions_$$
+    exit $exit_code
 }
 
 # Set up cleanup trap
@@ -121,32 +131,32 @@ trap cleanup EXIT INT TERM
 #==============================================================================
 
 validate_environment() {
-  # Check if we have a current branch/feature (git or non-git)
-  if [[ -z "$CURRENT_BRANCH" ]]; then
-    log_error "Unable to determine current feature"
-    if [[ "$HAS_GIT" == "true" ]]; then
-      log_info "Make sure you're on a feature branch"
-    else
-      log_info "Set SPECIFY_FEATURE environment variable or create a feature first"
+    # Check if we have a current branch/feature (git or non-git)
+    if [[ -z "$CURRENT_BRANCH" ]]; then
+        log_error "Unable to determine current feature"
+        if [[ "$HAS_GIT" == "true" ]]; then
+            log_info "Make sure you're on a feature branch"
+        else
+            log_info "Set SPECIFY_FEATURE environment variable or create a feature first"
+        fi
+        exit 1
     fi
-    exit 1
-  fi
-
-  # Check if plan.md exists
-  if [[ ! -f "$NEW_PLAN" ]]; then
-    log_error "No plan.md found at $NEW_PLAN"
-    log_info "Make sure you're working on a feature with a corresponding spec directory"
-    if [[ "$HAS_GIT" != "true" ]]; then
-      log_info "Use: export SPECIFY_FEATURE=your-feature-name or create a new feature first"
+    
+    # Check if plan.md exists
+    if [[ ! -f "$NEW_PLAN" ]]; then
+        log_error "No plan.md found at $NEW_PLAN"
+        log_info "Make sure you're working on a feature with a corresponding spec directory"
+        if [[ "$HAS_GIT" != "true" ]]; then
+            log_info "Use: export SPECIFY_FEATURE=your-feature-name or create a new feature first"
+        fi
+        exit 1
     fi
-    exit 1
-  fi
-
-  # Check if template exists (needed for new files)
-  if [[ ! -f "$TEMPLATE_FILE" ]]; then
-    log_warning "Template file not found at $TEMPLATE_FILE"
-    log_warning "Creating new agent files will fail"
-  fi
+    
+    # Check if template exists (needed for new files)
+    if [[ ! -f "$TEMPLATE_FILE" ]]; then
+        log_warning "Template file not found at $TEMPLATE_FILE"
+        log_warning "Creating new agent files will fail"
+    fi
 }
 
 #==============================================================================
@@ -154,79 +164,79 @@ validate_environment() {
 #==============================================================================
 
 extract_plan_field() {
-  local field_pattern="$1"
-  local plan_file="$2"
-
-  grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null \
-    | head -1 \
-    | sed "s|^\*\*${field_pattern}\*\*: ||" \
-    | sed 's/^[ \t]*//;s/[ \t]*$//' \
-    | grep -v "NEEDS CLARIFICATION" \
-    | grep -v "^N/A$" || echo ""
+    local field_pattern="$1"
+    local plan_file="$2"
+    
+    grep "^\*\*${field_pattern}\*\*: " "$plan_file" 2>/dev/null | \
+        head -1 | \
+        sed "s|^\*\*${field_pattern}\*\*: ||" | \
+        sed 's/^[ \t]*//;s/[ \t]*$//' | \
+        grep -v "NEEDS CLARIFICATION" | \
+        grep -v "^N/A$" || echo ""
 }
 
 parse_plan_data() {
-  local plan_file="$1"
-
-  if [[ ! -f "$plan_file" ]]; then
-    log_error "Plan file not found: $plan_file"
-    return 1
-  fi
-
-  if [[ ! -r "$plan_file" ]]; then
-    log_error "Plan file is not readable: $plan_file"
-    return 1
-  fi
-
-  log_info "Parsing plan data from $plan_file"
-
-  NEW_LANG=$(extract_plan_field "Language/Version" "$plan_file")
-  NEW_FRAMEWORK=$(extract_plan_field "Primary Dependencies" "$plan_file")
-  NEW_DB=$(extract_plan_field "Storage" "$plan_file")
-  NEW_PROJECT_TYPE=$(extract_plan_field "Project Type" "$plan_file")
-
-  # Log what we found
-  if [[ -n "$NEW_LANG" ]]; then
-    log_info "Found language: $NEW_LANG"
-  else
-    log_warning "No language information found in plan"
-  fi
-
-  if [[ -n "$NEW_FRAMEWORK" ]]; then
-    log_info "Found framework: $NEW_FRAMEWORK"
-  fi
-
-  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
-    log_info "Found database: $NEW_DB"
-  fi
-
-  if [[ -n "$NEW_PROJECT_TYPE" ]]; then
-    log_info "Found project type: $NEW_PROJECT_TYPE"
-  fi
+    local plan_file="$1"
+    
+    if [[ ! -f "$plan_file" ]]; then
+        log_error "Plan file not found: $plan_file"
+        return 1
+    fi
+    
+    if [[ ! -r "$plan_file" ]]; then
+        log_error "Plan file is not readable: $plan_file"
+        return 1
+    fi
+    
+    log_info "Parsing plan data from $plan_file"
+    
+    NEW_LANG=$(extract_plan_field "Language/Version" "$plan_file")
+    NEW_FRAMEWORK=$(extract_plan_field "Primary Dependencies" "$plan_file")
+    NEW_DB=$(extract_plan_field "Storage" "$plan_file")
+    NEW_PROJECT_TYPE=$(extract_plan_field "Project Type" "$plan_file")
+    
+    # Log what we found
+    if [[ -n "$NEW_LANG" ]]; then
+        log_info "Found language: $NEW_LANG"
+    else
+        log_warning "No language information found in plan"
+    fi
+    
+    if [[ -n "$NEW_FRAMEWORK" ]]; then
+        log_info "Found framework: $NEW_FRAMEWORK"
+    fi
+    
+    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+        log_info "Found database: $NEW_DB"
+    fi
+    
+    if [[ -n "$NEW_PROJECT_TYPE" ]]; then
+        log_info "Found project type: $NEW_PROJECT_TYPE"
+    fi
 }
 
 format_technology_stack() {
-  local lang="$1"
-  local framework="$2"
-  local parts=()
-
-  # Add non-empty parts
-  [[ -n "$lang" && "$lang" != "NEEDS CLARIFICATION" ]] && parts+=("$lang")
-  [[ -n "$framework" && "$framework" != "NEEDS CLARIFICATION" && "$framework" != "N/A" ]] && parts+=("$framework")
-
-  # Join with proper formatting
-  if [[ ${#parts[@]} -eq 0 ]]; then
-    echo ""
-  elif [[ ${#parts[@]} -eq 1 ]]; then
-    echo "${parts[0]}"
-  else
-    # Join multiple parts with " + "
-    local result="${parts[0]}"
-    for ((i = 1; i < ${#parts[@]}; i++)); do
-      result="$result + ${parts[i]}"
-    done
-    echo "$result"
-  fi
+    local lang="$1"
+    local framework="$2"
+    local parts=()
+    
+    # Add non-empty parts
+    [[ -n "$lang" && "$lang" != "NEEDS CLARIFICATION" ]] && parts+=("$lang")
+    [[ -n "$framework" && "$framework" != "NEEDS CLARIFICATION" && "$framework" != "N/A" ]] && parts+=("$framework")
+    
+    # Join with proper formatting
+    if [[ ${#parts[@]} -eq 0 ]]; then
+        echo ""
+    elif [[ ${#parts[@]} -eq 1 ]]; then
+        echo "${parts[0]}"
+    else
+        # Join multiple parts with " + "
+        local result="${parts[0]}"
+        for ((i=1; i<${#parts[@]}; i++)); do
+            result="$result + ${parts[i]}"
+        done
+        echo "$result"
+    fi
 }
 
 #==============================================================================
@@ -234,341 +244,364 @@ format_technology_stack() {
 #==============================================================================
 
 get_project_structure() {
-  local project_type="$1"
-
-  if [[ "$project_type" == *"web"* ]]; then
-    echo "backend/\\nfrontend/\\ntests/"
-  else
-    echo "src/\\ntests/"
-  fi
+    local project_type="$1"
+    
+    if [[ "$project_type" == *"web"* ]]; then
+        echo "backend/\\nfrontend/\\ntests/"
+    else
+        echo "src/\\ntests/"
+    fi
 }
 
 get_commands_for_language() {
-  local lang="$1"
-
-  case "$lang" in
-    *"Python"*)
-      echo "cd src && pytest && ruff check ."
-      ;;
-    *"Rust"*)
-      echo "cargo test && cargo clippy"
-      ;;
-    *"JavaScript"* | *"TypeScript"*)
-      echo "npm test \\&\\& npm run lint"
-      ;;
-    *)
-      echo "# Add commands for $lang"
-      ;;
-  esac
+    local lang="$1"
+    
+    case "$lang" in
+        *"Python"*)
+            echo "cd src && pytest && ruff check ."
+            ;;
+        *"Rust"*)
+            echo "cargo test && cargo clippy"
+            ;;
+        *"JavaScript"*|*"TypeScript"*)
+            echo "npm test \\&\\& npm run lint"
+            ;;
+        *)
+            echo "# Add commands for $lang"
+            ;;
+    esac
 }
 
 get_language_conventions() {
-  local lang="$1"
-  echo "$lang: Follow standard conventions"
+    local lang="$1"
+    echo "$lang: Follow standard conventions"
 }
 
 create_new_agent_file() {
-  local target_file="$1"
-  local temp_file="$2"
-  local project_name="$3"
-  local current_date="$4"
-
-  if [[ ! -f "$TEMPLATE_FILE" ]]; then
-    log_error "Template not found at $TEMPLATE_FILE"
-    return 1
-  fi
-
-  if [[ ! -r "$TEMPLATE_FILE" ]]; then
-    log_error "Template file is not readable: $TEMPLATE_FILE"
-    return 1
-  fi
-
-  log_info "Creating new agent context file from template..."
-
-  if ! cp "$TEMPLATE_FILE" "$temp_file"; then
-    log_error "Failed to copy template file"
-    return 1
-  fi
-
-  # Replace template placeholders
-  local project_structure
-  project_structure=$(get_project_structure "$NEW_PROJECT_TYPE")
-
-  local commands
-  commands=$(get_commands_for_language "$NEW_LANG")
-
-  local language_conventions
-  language_conventions=$(get_language_conventions "$NEW_LANG")
-
-  # Perform substitutions with error checking using safer approach
-  # Escape special characters for sed by using a different delimiter or escaping
-  local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-  local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-  local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
-
-  # Build technology stack and recent change strings conditionally
-  local tech_stack
-  if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
-    tech_stack="- $escaped_lang + $escaped_framework ($escaped_branch)"
-  elif [[ -n "$escaped_lang" ]]; then
-    tech_stack="- $escaped_lang ($escaped_branch)"
-  elif [[ -n "$escaped_framework" ]]; then
-    tech_stack="- $escaped_framework ($escaped_branch)"
-  else
-    tech_stack="- ($escaped_branch)"
-  fi
-
-  local recent_change
-  if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
-    recent_change="- $escaped_branch: Added $escaped_lang + $escaped_framework"
-  elif [[ -n "$escaped_lang" ]]; then
-    recent_change="- $escaped_branch: Added $escaped_lang"
-  elif [[ -n "$escaped_framework" ]]; then
-    recent_change="- $escaped_branch: Added $escaped_framework"
-  else
-    recent_change="- $escaped_branch: Added"
-  fi
-
-  local substitutions=(
-    "s|\[PROJECT NAME\]|$project_name|"
-    "s|\[DATE\]|$current_date|"
-    "s|\[EXTRACTED FROM ALL PLAN.MD FILES\]|$tech_stack|"
-    "s|\[ACTUAL STRUCTURE FROM PLANS\]|$project_structure|g"
-    "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$commands|"
-    "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
-    "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
-  )
-
-  for substitution in "${substitutions[@]}"; do
-    if ! sed -i.bak -e "$substitution" "$temp_file"; then
-      log_error "Failed to perform substitution: $substitution"
-      rm -f "$temp_file" "$temp_file.bak"
-      return 1
+    local target_file="$1"
+    local temp_file="$2"
+    local project_name="$3"
+    local current_date="$4"
+    
+    if [[ ! -f "$TEMPLATE_FILE" ]]; then
+        log_error "Template not found at $TEMPLATE_FILE"
+        return 1
     fi
-  done
+    
+    if [[ ! -r "$TEMPLATE_FILE" ]]; then
+        log_error "Template file is not readable: $TEMPLATE_FILE"
+        return 1
+    fi
+    
+    log_info "Creating new agent context file from template..."
+    
+    if ! cp "$TEMPLATE_FILE" "$temp_file"; then
+        log_error "Failed to copy template file"
+        return 1
+    fi
+    
+    # Replace template placeholders
+    local project_structure
+    project_structure=$(get_project_structure "$NEW_PROJECT_TYPE")
+    
+    local commands
+    commands=$(get_commands_for_language "$NEW_LANG")
+    
+    local language_conventions
+    language_conventions=$(get_language_conventions "$NEW_LANG")
+    
+    # Perform substitutions with error checking using safer approach
+    # Escape special characters for sed by using a different delimiter or escaping
+    local escaped_lang=$(printf '%s\n' "$NEW_LANG" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+    local escaped_framework=$(printf '%s\n' "$NEW_FRAMEWORK" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+    local escaped_branch=$(printf '%s\n' "$CURRENT_BRANCH" | sed 's/[\[\.*^$()+{}|]/\\&/g')
+    
+    # Build technology stack and recent change strings conditionally
+    local tech_stack
+    if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
+        tech_stack="- $escaped_lang + $escaped_framework ($escaped_branch)"
+    elif [[ -n "$escaped_lang" ]]; then
+        tech_stack="- $escaped_lang ($escaped_branch)"
+    elif [[ -n "$escaped_framework" ]]; then
+        tech_stack="- $escaped_framework ($escaped_branch)"
+    else
+        tech_stack="- ($escaped_branch)"
+    fi
 
-  # Convert \n sequences to actual newlines
-  newline=$(printf '\n')
-  sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
+    local recent_change
+    if [[ -n "$escaped_lang" && -n "$escaped_framework" ]]; then
+        recent_change="- $escaped_branch: Added $escaped_lang + $escaped_framework"
+    elif [[ -n "$escaped_lang" ]]; then
+        recent_change="- $escaped_branch: Added $escaped_lang"
+    elif [[ -n "$escaped_framework" ]]; then
+        recent_change="- $escaped_branch: Added $escaped_framework"
+    else
+        recent_change="- $escaped_branch: Added"
+    fi
 
-  # Clean up backup files
-  rm -f "$temp_file.bak" "$temp_file.bak2"
+    local substitutions=(
+        "s|\[PROJECT NAME\]|$project_name|"
+        "s|\[DATE\]|$current_date|"
+        "s|\[EXTRACTED FROM ALL PLAN.MD FILES\]|$tech_stack|"
+        "s|\[ACTUAL STRUCTURE FROM PLANS\]|$project_structure|g"
+        "s|\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]|$commands|"
+        "s|\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]|$language_conventions|"
+        "s|\[LAST 3 FEATURES AND WHAT THEY ADDED\]|$recent_change|"
+    )
+    
+    for substitution in "${substitutions[@]}"; do
+        if ! sed -i.bak -e "$substitution" "$temp_file"; then
+            log_error "Failed to perform substitution: $substitution"
+            rm -f "$temp_file" "$temp_file.bak"
+            return 1
+        fi
+    done
+    
+    # Convert \n sequences to actual newlines
+    newline=$(printf '\n')
+    sed -i.bak2 "s/\\\\n/${newline}/g" "$temp_file"
 
-  return 0
+    # Clean up backup files
+    rm -f "$temp_file.bak" "$temp_file.bak2"
+
+    # Prepend Cursor frontmatter for .mdc files so rules are auto-included
+    if [[ "$target_file" == *.mdc ]]; then
+        local frontmatter_file
+        frontmatter_file=$(mktemp) || return 1
+        printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
+        cat "$temp_file" >> "$frontmatter_file"
+        mv "$frontmatter_file" "$temp_file"
+    fi
+
+    return 0
 }
 
+
+
+
 update_existing_agent_file() {
-  local target_file="$1"
-  local current_date="$2"
-
-  log_info "Updating existing agent context file..."
-
-  # Use a single temporary file for atomic update
-  local temp_file
-  temp_file=$(mktemp) || {
-    log_error "Failed to create temporary file"
-    return 1
-  }
-
-  # Process the file in one pass
-  local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
-  local new_tech_entries=()
-  local new_change_entry=""
-
-  # Prepare new technology entries
-  if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
-    new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
-  fi
-
-  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
-    new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
-  fi
-
-  # Prepare new change entry
-  if [[ -n "$tech_stack" ]]; then
-    new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
-  elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
-    new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
-  fi
-
-  # Check if sections exist in the file
-  local has_active_technologies=0
-  local has_recent_changes=0
-
-  if grep -q "^## Active Technologies" "$target_file" 2>/dev/null; then
-    has_active_technologies=1
-  fi
-
-  if grep -q "^## Recent Changes" "$target_file" 2>/dev/null; then
-    has_recent_changes=1
-  fi
-
-  # Process file line by line
-  local in_tech_section=false
-  local in_changes_section=false
-  local tech_entries_added=false
-  local changes_entries_added=false
-  local existing_changes_count=0
-  local file_ended=false
-
-  while IFS= read -r line || [[ -n "$line" ]]; do
-    # Handle Active Technologies section
-    if [[ "$line" == "## Active Technologies" ]]; then
-      echo "$line" >>"$temp_file"
-      in_tech_section=true
-      continue
-    elif [[ $in_tech_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-      # Add new tech entries before closing the section
-      if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
+    local target_file="$1"
+    local current_date="$2"
+    
+    log_info "Updating existing agent context file..."
+    
+    # Use a single temporary file for atomic update
+    local temp_file
+    temp_file=$(mktemp) || {
+        log_error "Failed to create temporary file"
+        return 1
+    }
+    
+    # Process the file in one pass
+    local tech_stack=$(format_technology_stack "$NEW_LANG" "$NEW_FRAMEWORK")
+    local new_tech_entries=()
+    local new_change_entry=""
+    
+    # Prepare new technology entries
+    if [[ -n "$tech_stack" ]] && ! grep -q "$tech_stack" "$target_file"; then
+        new_tech_entries+=("- $tech_stack ($CURRENT_BRANCH)")
+    fi
+    
+    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]] && ! grep -q "$NEW_DB" "$target_file"; then
+        new_tech_entries+=("- $NEW_DB ($CURRENT_BRANCH)")
+    fi
+    
+    # Prepare new change entry
+    if [[ -n "$tech_stack" ]]; then
+        new_change_entry="- $CURRENT_BRANCH: Added $tech_stack"
+    elif [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]] && [[ "$NEW_DB" != "NEEDS CLARIFICATION" ]]; then
+        new_change_entry="- $CURRENT_BRANCH: Added $NEW_DB"
+    fi
+    
+    # Check if sections exist in the file
+    local has_active_technologies=0
+    local has_recent_changes=0
+    
+    if grep -q "^## Active Technologies" "$target_file" 2>/dev/null; then
+        has_active_technologies=1
+    fi
+    
+    if grep -q "^## Recent Changes" "$target_file" 2>/dev/null; then
+        has_recent_changes=1
+    fi
+    
+    # Process file line by line
+    local in_tech_section=false
+    local in_changes_section=false
+    local tech_entries_added=false
+    local changes_entries_added=false
+    local existing_changes_count=0
+    local file_ended=false
+    
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        # Handle Active Technologies section
+        if [[ "$line" == "## Active Technologies" ]]; then
+            echo "$line" >> "$temp_file"
+            in_tech_section=true
+            continue
+        elif [[ $in_tech_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
+            # Add new tech entries before closing the section
+            if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+                tech_entries_added=true
+            fi
+            echo "$line" >> "$temp_file"
+            in_tech_section=false
+            continue
+        elif [[ $in_tech_section == true ]] && [[ -z "$line" ]]; then
+            # Add new tech entries before empty line in tech section
+            if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+                printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
+                tech_entries_added=true
+            fi
+            echo "$line" >> "$temp_file"
+            continue
+        fi
+        
+        # Handle Recent Changes section
+        if [[ "$line" == "## Recent Changes" ]]; then
+            echo "$line" >> "$temp_file"
+            # Add new change entry right after the heading
+            if [[ -n "$new_change_entry" ]]; then
+                echo "$new_change_entry" >> "$temp_file"
+            fi
+            in_changes_section=true
+            changes_entries_added=true
+            continue
+        elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
+            echo "$line" >> "$temp_file"
+            in_changes_section=false
+            continue
+        elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
+            # Keep only first 2 existing changes
+            if [[ $existing_changes_count -lt 2 ]]; then
+                echo "$line" >> "$temp_file"
+                ((existing_changes_count++))
+            fi
+            continue
+        fi
+        
+        # Update timestamp
+        if [[ "$line" =~ (\*\*)?Last\ updated(\*\*)?:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
+            echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >> "$temp_file"
+        else
+            echo "$line" >> "$temp_file"
+        fi
+    done < "$target_file"
+    
+    # Post-loop check: if we're still in the Active Technologies section and haven't added new entries
+    if [[ $in_tech_section == true ]] && [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+        printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
         tech_entries_added=true
-      fi
-      echo "$line" >>"$temp_file"
-      in_tech_section=false
-      continue
-    elif [[ $in_tech_section == true ]] && [[ -z "$line" ]]; then
-      # Add new tech entries before empty line in tech section
-      if [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-        printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
+    fi
+    
+    # If sections don't exist, add them at the end of the file
+    if [[ $has_active_technologies -eq 0 ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
+        echo "" >> "$temp_file"
+        echo "## Active Technologies" >> "$temp_file"
+        printf '%s\n' "${new_tech_entries[@]}" >> "$temp_file"
         tech_entries_added=true
-      fi
-      echo "$line" >>"$temp_file"
-      continue
+    fi
+    
+    if [[ $has_recent_changes -eq 0 ]] && [[ -n "$new_change_entry" ]]; then
+        echo "" >> "$temp_file"
+        echo "## Recent Changes" >> "$temp_file"
+        echo "$new_change_entry" >> "$temp_file"
+        changes_entries_added=true
+    fi
+    
+    # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
+    if [[ "$target_file" == *.mdc ]]; then
+        if ! head -1 "$temp_file" | grep -q '^---'; then
+            local frontmatter_file
+            frontmatter_file=$(mktemp) || { rm -f "$temp_file"; return 1; }
+            printf '%s\n' "---" "description: Project Development Guidelines" "globs: [\"**/*\"]" "alwaysApply: true" "---" "" > "$frontmatter_file"
+            cat "$temp_file" >> "$frontmatter_file"
+            mv "$frontmatter_file" "$temp_file"
+        fi
     fi
 
-    # Handle Recent Changes section
-    if [[ "$line" == "## Recent Changes" ]]; then
-      echo "$line" >>"$temp_file"
-      # Add new change entry right after the heading
-      if [[ -n "$new_change_entry" ]]; then
-        echo "$new_change_entry" >>"$temp_file"
-      fi
-      in_changes_section=true
-      changes_entries_added=true
-      continue
-    elif [[ $in_changes_section == true ]] && [[ "$line" =~ ^##[[:space:]] ]]; then
-      echo "$line" >>"$temp_file"
-      in_changes_section=false
-      continue
-    elif [[ $in_changes_section == true ]] && [[ "$line" == "- "* ]]; then
-      # Keep only first 2 existing changes
-      if [[ $existing_changes_count -lt 2 ]]; then
-        echo "$line" >>"$temp_file"
-        ((existing_changes_count++))
-      fi
-      continue
+    # Move temp file to target atomically
+    if ! mv "$temp_file" "$target_file"; then
+        log_error "Failed to update target file"
+        rm -f "$temp_file"
+        return 1
     fi
 
-    # Update timestamp
-    if [[ "$line" =~ \*\*Last\ updated\*\*:.*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9] ]]; then
-      echo "$line" | sed "s/[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/$current_date/" >>"$temp_file"
-    else
-      echo "$line" >>"$temp_file"
-    fi
-  done <"$target_file"
-
-  # Post-loop check: if we're still in the Active Technologies section and haven't added new entries
-  if [[ $in_tech_section == true ]] && [[ $tech_entries_added == false ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-    printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
-    tech_entries_added=true
-  fi
-
-  # If sections don't exist, add them at the end of the file
-  if [[ $has_active_technologies -eq 0 ]] && [[ ${#new_tech_entries[@]} -gt 0 ]]; then
-    echo "" >>"$temp_file"
-    echo "## Active Technologies" >>"$temp_file"
-    printf '%s\n' "${new_tech_entries[@]}" >>"$temp_file"
-    tech_entries_added=true
-  fi
-
-  if [[ $has_recent_changes -eq 0 ]] && [[ -n "$new_change_entry" ]]; then
-    echo "" >>"$temp_file"
-    echo "## Recent Changes" >>"$temp_file"
-    echo "$new_change_entry" >>"$temp_file"
-    changes_entries_added=true
-  fi
-
-  # Move temp file to target atomically
-  if ! mv "$temp_file" "$target_file"; then
-    log_error "Failed to update target file"
-    rm -f "$temp_file"
-    return 1
-  fi
-
-  return 0
+    return 0
 }
 #==============================================================================
 # Main Agent File Update Function
 #==============================================================================
 
 update_agent_file() {
-  local target_file="$1"
-  local agent_name="$2"
-
-  if [[ -z "$target_file" ]] || [[ -z "$agent_name" ]]; then
-    log_error "update_agent_file requires target_file and agent_name parameters"
-    return 1
-  fi
-
-  log_info "Updating $agent_name context file: $target_file"
-
-  local project_name
-  project_name=$(basename "$REPO_ROOT")
-  local current_date
-  current_date=$(date +%Y-%m-%d)
-
-  # Create directory if it doesn't exist
-  local target_dir
-  target_dir=$(dirname "$target_file")
-  if [[ ! -d "$target_dir" ]]; then
-    if ! mkdir -p "$target_dir"; then
-      log_error "Failed to create directory: $target_dir"
-      return 1
-    fi
-  fi
-
-  if [[ ! -f "$target_file" ]]; then
-    # Create new file from template
-    local temp_file
-    temp_file=$(mktemp) || {
-      log_error "Failed to create temporary file"
-      return 1
-    }
-
-    if create_new_agent_file "$target_file" "$temp_file" "$project_name" "$current_date"; then
-      if mv "$temp_file" "$target_file"; then
-        log_success "Created new $agent_name context file"
-      else
-        log_error "Failed to move temporary file to $target_file"
-        rm -f "$temp_file"
+    local target_file="$1"
+    local agent_name="$2"
+    
+    if [[ -z "$target_file" ]] || [[ -z "$agent_name" ]]; then
+        log_error "update_agent_file requires target_file and agent_name parameters"
         return 1
-      fi
+    fi
+    
+    log_info "Updating $agent_name context file: $target_file"
+    
+    local project_name
+    project_name=$(basename "$REPO_ROOT")
+    local current_date
+    current_date=$(date +%Y-%m-%d)
+    
+    # Create directory if it doesn't exist
+    local target_dir
+    target_dir=$(dirname "$target_file")
+    if [[ ! -d "$target_dir" ]]; then
+        if ! mkdir -p "$target_dir"; then
+            log_error "Failed to create directory: $target_dir"
+            return 1
+        fi
+    fi
+    
+    if [[ ! -f "$target_file" ]]; then
+        # Create new file from template
+        local temp_file
+        temp_file=$(mktemp) || {
+            log_error "Failed to create temporary file"
+            return 1
+        }
+        
+        if create_new_agent_file "$target_file" "$temp_file" "$project_name" "$current_date"; then
+            if mv "$temp_file" "$target_file"; then
+                log_success "Created new $agent_name context file"
+            else
+                log_error "Failed to move temporary file to $target_file"
+                rm -f "$temp_file"
+                return 1
+            fi
+        else
+            log_error "Failed to create new agent file"
+            rm -f "$temp_file"
+            return 1
+        fi
     else
-      log_error "Failed to create new agent file"
-      rm -f "$temp_file"
-      return 1
+        # Update existing file
+        if [[ ! -r "$target_file" ]]; then
+            log_error "Cannot read existing file: $target_file"
+            return 1
+        fi
+        
+        if [[ ! -w "$target_file" ]]; then
+            log_error "Cannot write to existing file: $target_file"
+            return 1
+        fi
+        
+        if update_existing_agent_file "$target_file" "$current_date"; then
+            log_success "Updated existing $agent_name context file"
+        else
+            log_error "Failed to update existing agent file"
+            return 1
+        fi
     fi
-  else
-    # Update existing file
-    if [[ ! -r "$target_file" ]]; then
-      log_error "Cannot read existing file: $target_file"
-      return 1
-    fi
-
-    if [[ ! -w "$target_file" ]]; then
-      log_error "Cannot write to existing file: $target_file"
-      return 1
-    fi
-
-    if update_existing_agent_file "$target_file" "$current_date"; then
-      log_success "Updated existing $agent_name context file"
-    else
-      log_error "Failed to update existing agent file"
-      return 1
-    fi
-  fi
-
-  return 0
+    
+    return 0
 }
 
 #==============================================================================
@@ -576,172 +609,152 @@ update_agent_file() {
 #==============================================================================
 
 update_specific_agent() {
-  local agent_type="$1"
-
-  case "$agent_type" in
-    claude)
-      update_agent_file "$CLAUDE_FILE" "Claude Code"
-      ;;
-    gemini)
-      update_agent_file "$GEMINI_FILE" "Gemini CLI"
-      ;;
-    copilot)
-      update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-      ;;
-    cursor-agent)
-      update_agent_file "$CURSOR_FILE" "Cursor IDE"
-      ;;
-    qwen)
-      update_agent_file "$QWEN_FILE" "Qwen Code"
-      ;;
-    opencode)
-      update_agent_file "$AGENTS_FILE" "opencode"
-      ;;
-    codex)
-      update_agent_file "$AGENTS_FILE" "Codex CLI"
-      ;;
-    windsurf)
-      update_agent_file "$WINDSURF_FILE" "Windsurf"
-      ;;
-    kilocode)
-      update_agent_file "$KILOCODE_FILE" "Kilo Code"
-      ;;
-    auggie)
-      update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-      ;;
-    roo)
-      update_agent_file "$ROO_FILE" "Roo Code"
-      ;;
-    codebuddy)
-      update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-      ;;
-    qoder)
-      update_agent_file "$QODER_FILE" "Qoder CLI"
-      ;;
-    amp)
-      update_agent_file "$AMP_FILE" "Amp"
-      ;;
-    shai)
-      update_agent_file "$SHAI_FILE" "SHAI"
-      ;;
-    q)
-      update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-      ;;
-    bob)
-      update_agent_file "$BOB_FILE" "IBM Bob"
-      ;;
-    *)
-      log_error "Unknown agent type '$agent_type'"
-      log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|amp|shai|q|bob|qoder"
-      exit 1
-      ;;
-  esac
+    local agent_type="$1"
+    
+    case "$agent_type" in
+        claude)
+            update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
+            ;;
+        gemini)
+            update_agent_file "$GEMINI_FILE" "Gemini CLI" || return 1
+            ;;
+        copilot)
+            update_agent_file "$COPILOT_FILE" "GitHub Copilot" || return 1
+            ;;
+        cursor-agent)
+            update_agent_file "$CURSOR_FILE" "Cursor IDE" || return 1
+            ;;
+        qwen)
+            update_agent_file "$QWEN_FILE" "Qwen Code" || return 1
+            ;;
+        opencode)
+            update_agent_file "$AGENTS_FILE" "opencode" || return 1
+            ;;
+        codex)
+            update_agent_file "$AGENTS_FILE" "Codex CLI" || return 1
+            ;;
+        windsurf)
+            update_agent_file "$WINDSURF_FILE" "Windsurf" || return 1
+            ;;
+        kilocode)
+            update_agent_file "$KILOCODE_FILE" "Kilo Code" || return 1
+            ;;
+        auggie)
+            update_agent_file "$AUGGIE_FILE" "Auggie CLI" || return 1
+            ;;
+        roo)
+            update_agent_file "$ROO_FILE" "Roo Code" || return 1
+            ;;
+        codebuddy)
+            update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI" || return 1
+            ;;
+        qodercli)
+            update_agent_file "$QODER_FILE" "Qoder CLI" || return 1
+            ;;
+        amp)
+            update_agent_file "$AMP_FILE" "Amp" || return 1
+            ;;
+        shai)
+            update_agent_file "$SHAI_FILE" "SHAI" || return 1
+            ;;
+        tabnine)
+            update_agent_file "$TABNINE_FILE" "Tabnine CLI" || return 1
+            ;;
+        kiro-cli)
+            update_agent_file "$KIRO_FILE" "Kiro CLI" || return 1
+            ;;
+        agy)
+            update_agent_file "$AGY_FILE" "Antigravity" || return 1
+            ;;
+        bob)
+            update_agent_file "$BOB_FILE" "IBM Bob" || return 1
+            ;;
+        vibe)
+            update_agent_file "$VIBE_FILE" "Mistral Vibe" || return 1
+            ;;
+        kimi)
+            update_agent_file "$KIMI_FILE" "Kimi Code" || return 1
+            ;;
+        generic)
+            log_info "Generic agent: no predefined context file. Use the agent-specific update script for your agent."
+            ;;
+        *)
+            log_error "Unknown agent type '$agent_type'"
+            log_error "Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic"
+            exit 1
+            ;;
+    esac
 }
 
 update_all_existing_agents() {
-  local found_agent=false
+    local found_agent=false
+    local _updated_paths=()
 
-  # Check each possible agent file and update if it exists
-  if [[ -f "$CLAUDE_FILE" ]]; then
-    update_agent_file "$CLAUDE_FILE" "Claude Code"
-    found_agent=true
-  fi
+    # Helper: skip non-existent files and files already updated (dedup by
+    # realpath so that variables pointing to the same file — e.g. AMP_FILE,
+    # KIRO_FILE, BOB_FILE all resolving to AGENTS_FILE — are only written once).
+    # Uses a linear array instead of associative array for bash 3.2 compatibility.
+    update_if_new() {
+        local file="$1" name="$2"
+        [[ -f "$file" ]] || return 0
+        local real_path
+        real_path=$(realpath "$file" 2>/dev/null || echo "$file")
+        local p
+        if [[ ${#_updated_paths[@]} -gt 0 ]]; then
+            for p in "${_updated_paths[@]}"; do
+                [[ "$p" == "$real_path" ]] && return 0
+            done
+        fi
+        update_agent_file "$file" "$name" || return 1
+        _updated_paths+=("$real_path")
+        found_agent=true
+    }
 
-  if [[ -f "$GEMINI_FILE" ]]; then
-    update_agent_file "$GEMINI_FILE" "Gemini CLI"
-    found_agent=true
-  fi
+    update_if_new "$CLAUDE_FILE" "Claude Code"
+    update_if_new "$GEMINI_FILE" "Gemini CLI"
+    update_if_new "$COPILOT_FILE" "GitHub Copilot"
+    update_if_new "$CURSOR_FILE" "Cursor IDE"
+    update_if_new "$QWEN_FILE" "Qwen Code"
+    update_if_new "$AGENTS_FILE" "Codex/opencode"
+    update_if_new "$AMP_FILE" "Amp"
+    update_if_new "$KIRO_FILE" "Kiro CLI"
+    update_if_new "$BOB_FILE" "IBM Bob"
+    update_if_new "$WINDSURF_FILE" "Windsurf"
+    update_if_new "$KILOCODE_FILE" "Kilo Code"
+    update_if_new "$AUGGIE_FILE" "Auggie CLI"
+    update_if_new "$ROO_FILE" "Roo Code"
+    update_if_new "$CODEBUDDY_FILE" "CodeBuddy CLI"
+    update_if_new "$SHAI_FILE" "SHAI"
+    update_if_new "$TABNINE_FILE" "Tabnine CLI"
+    update_if_new "$QODER_FILE" "Qoder CLI"
+    update_if_new "$AGY_FILE" "Antigravity"
+    update_if_new "$VIBE_FILE" "Mistral Vibe"
+    update_if_new "$KIMI_FILE" "Kimi Code"
 
-  if [[ -f "$COPILOT_FILE" ]]; then
-    update_agent_file "$COPILOT_FILE" "GitHub Copilot"
-    found_agent=true
-  fi
-
-  if [[ -f "$CURSOR_FILE" ]]; then
-    update_agent_file "$CURSOR_FILE" "Cursor IDE"
-    found_agent=true
-  fi
-
-  if [[ -f "$QWEN_FILE" ]]; then
-    update_agent_file "$QWEN_FILE" "Qwen Code"
-    found_agent=true
-  fi
-
-  if [[ -f "$AGENTS_FILE" ]]; then
-    update_agent_file "$AGENTS_FILE" "Codex/opencode"
-    found_agent=true
-  fi
-
-  if [[ -f "$WINDSURF_FILE" ]]; then
-    update_agent_file "$WINDSURF_FILE" "Windsurf"
-    found_agent=true
-  fi
-
-  if [[ -f "$KILOCODE_FILE" ]]; then
-    update_agent_file "$KILOCODE_FILE" "Kilo Code"
-    found_agent=true
-  fi
-
-  if [[ -f "$AUGGIE_FILE" ]]; then
-    update_agent_file "$AUGGIE_FILE" "Auggie CLI"
-    found_agent=true
-  fi
-
-  if [[ -f "$ROO_FILE" ]]; then
-    update_agent_file "$ROO_FILE" "Roo Code"
-    found_agent=true
-  fi
-
-  if [[ -f "$CODEBUDDY_FILE" ]]; then
-    update_agent_file "$CODEBUDDY_FILE" "CodeBuddy CLI"
-    found_agent=true
-  fi
-
-  if [[ -f "$SHAI_FILE" ]]; then
-    update_agent_file "$SHAI_FILE" "SHAI"
-    found_agent=true
-  fi
-
-  if [[ -f "$QODER_FILE" ]]; then
-    update_agent_file "$QODER_FILE" "Qoder CLI"
-    found_agent=true
-  fi
-
-  if [[ -f "$Q_FILE" ]]; then
-    update_agent_file "$Q_FILE" "Amazon Q Developer CLI"
-    found_agent=true
-  fi
-
-  if [[ -f "$BOB_FILE" ]]; then
-    update_agent_file "$BOB_FILE" "IBM Bob"
-    found_agent=true
-  fi
-
-  # If no agent files exist, create a default Claude file
-  if [[ "$found_agent" == false ]]; then
-    log_info "No existing agent files found, creating default Claude file..."
-    update_agent_file "$CLAUDE_FILE" "Claude Code"
-  fi
+    # If no agent files exist, create a default Claude file
+    if [[ "$found_agent" == false ]]; then
+        log_info "No existing agent files found, creating default Claude file..."
+        update_agent_file "$CLAUDE_FILE" "Claude Code" || return 1
+    fi
 }
 print_summary() {
-  echo
-  log_info "Summary of changes:"
-
-  if [[ -n "$NEW_LANG" ]]; then
-    echo "  - Added language: $NEW_LANG"
-  fi
-
-  if [[ -n "$NEW_FRAMEWORK" ]]; then
-    echo "  - Added framework: $NEW_FRAMEWORK"
-  fi
-
-  if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
-    echo "  - Added database: $NEW_DB"
-  fi
-
-  echo
-
-  log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|codebuddy|shai|q|bob|qoder]"
+    echo
+    log_info "Summary of changes:"
+    
+    if [[ -n "$NEW_LANG" ]]; then
+        echo "  - Added language: $NEW_LANG"
+    fi
+    
+    if [[ -n "$NEW_FRAMEWORK" ]]; then
+        echo "  - Added framework: $NEW_FRAMEWORK"
+    fi
+    
+    if [[ -n "$NEW_DB" ]] && [[ "$NEW_DB" != "N/A" ]]; then
+        echo "  - Added database: $NEW_DB"
+    fi
+    
+    echo
+    log_info "Usage: $0 [claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic]"
 }
 
 #==============================================================================
@@ -749,47 +762,47 @@ print_summary() {
 #==============================================================================
 
 main() {
-  # Validate environment before proceeding
-  validate_environment
-
-  log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
-
-  # Parse the plan file to extract project information
-  if ! parse_plan_data "$NEW_PLAN"; then
-    log_error "Failed to parse plan data"
-    exit 1
-  fi
-
-  # Process based on agent type argument
-  local success=true
-
-  if [[ -z "$AGENT_TYPE" ]]; then
-    # No specific agent provided - update all existing agent files
-    log_info "No agent specified, updating all existing agent files..."
-    if ! update_all_existing_agents; then
-      success=false
+    # Validate environment before proceeding
+    validate_environment
+    
+    log_info "=== Updating agent context files for feature $CURRENT_BRANCH ==="
+    
+    # Parse the plan file to extract project information
+    if ! parse_plan_data "$NEW_PLAN"; then
+        log_error "Failed to parse plan data"
+        exit 1
     fi
-  else
-    # Specific agent provided - update only that agent
-    log_info "Updating specific agent: $AGENT_TYPE"
-    if ! update_specific_agent "$AGENT_TYPE"; then
-      success=false
+    
+    # Process based on agent type argument
+    local success=true
+    
+    if [[ -z "$AGENT_TYPE" ]]; then
+        # No specific agent provided - update all existing agent files
+        log_info "No agent specified, updating all existing agent files..."
+        if ! update_all_existing_agents; then
+            success=false
+        fi
+    else
+        # Specific agent provided - update only that agent
+        log_info "Updating specific agent: $AGENT_TYPE"
+        if ! update_specific_agent "$AGENT_TYPE"; then
+            success=false
+        fi
     fi
-  fi
-
-  # Print summary
-  print_summary
-
-  if [[ "$success" == true ]]; then
-    log_success "Agent context update completed successfully"
-    exit 0
-  else
-    log_error "Agent context update completed with errors"
-    exit 1
-  fi
+    
+    # Print summary
+    print_summary
+    
+    if [[ "$success" == true ]]; then
+        log_success "Agent context update completed successfully"
+        exit 0
+    else
+        log_error "Agent context update completed with errors"
+        exit 1
+    fi
 }
 
 # Execute main function if script is run directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  main "$@"
+    main "$@"
 fi

--- a/.specify/scripts/powershell/check-prerequisites.ps1
+++ b/.specify/scripts/powershell/check-prerequisites.ps1
@@ -42,10 +42,10 @@ OPTIONS:
 EXAMPLES:
   # Check task prerequisites (plan.md required)
   .\check-prerequisites.ps1 -Json
-  
+
   # Check implementation prerequisites (plan.md + tasks.md required)
   .\check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
-  
+
   # Get feature paths only (no validation)
   .\check-prerequisites.ps1 -PathsOnly
 
@@ -59,8 +59,8 @@ EXAMPLES:
 # Get feature paths and validate branch
 $paths = Get-FeaturePathsEnv
 
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) { 
-    exit 1 
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) {
+    exit 1
 }
 
 # If paths-only mode, output paths and exit (support combined -Json -PathsOnly)
@@ -114,36 +114,36 @@ if (Test-Path $paths.RESEARCH) { $docs += 'research.md' }
 if (Test-Path $paths.DATA_MODEL) { $docs += 'data-model.md' }
 
 # Check contracts directory (only if it exists and has files)
-if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) { 
-    $docs += 'contracts/' 
+if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) {
+    $docs += 'contracts/'
 }
 
 if (Test-Path $paths.QUICKSTART) { $docs += 'quickstart.md' }
 
 # Include tasks.md if requested and it exists
-if ($IncludeTasks -and (Test-Path $paths.TASKS)) { 
-    $docs += 'tasks.md' 
+if ($IncludeTasks -and (Test-Path $paths.TASKS)) {
+    $docs += 'tasks.md'
 }
 
 # Output results
 if ($Json) {
     # JSON output
-    [PSCustomObject]@{ 
+    [PSCustomObject]@{
         FEATURE_DIR    = $paths.FEATURE_DIR
-        AVAILABLE_DOCS = $docs 
+        AVAILABLE_DOCS = $docs
     } | ConvertTo-Json -Compress
 }
 else {
     # Text output
     Write-Output "FEATURE_DIR:$($paths.FEATURE_DIR)"
     Write-Output "AVAILABLE_DOCS:"
-    
+
     # Show status of each potential document
     Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
     Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
     Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
     Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
-    
+
     if ($IncludeTasks) {
         Test-FileExists -Path $paths.TASKS -Description 'tasks.md' | Out-Null
     }

--- a/.specify/scripts/powershell/check-prerequisites.ps1
+++ b/.specify/scripts/powershell/check-prerequisites.ps1
@@ -42,10 +42,10 @@ OPTIONS:
 EXAMPLES:
   # Check task prerequisites (plan.md required)
   .\check-prerequisites.ps1 -Json
-
+  
   # Check implementation prerequisites (plan.md + tasks.md required)
   .\check-prerequisites.ps1 -Json -RequireTasks -IncludeTasks
-
+  
   # Get feature paths only (no validation)
   .\check-prerequisites.ps1 -PathsOnly
 
@@ -59,8 +59,8 @@ EXAMPLES:
 # Get feature paths and validate branch
 $paths = Get-FeaturePathsEnv
 
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) {
-    exit 1
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit:$paths.HAS_GIT)) { 
+    exit 1 
 }
 
 # If paths-only mode, output paths and exit (support combined -Json -PathsOnly)
@@ -74,8 +74,7 @@ if ($PathsOnly) {
             IMPL_PLAN    = $paths.IMPL_PLAN
             TASKS        = $paths.TASKS
         } | ConvertTo-Json -Compress
-    }
-    else {
+    } else {
         Write-Output "REPO_ROOT: $($paths.REPO_ROOT)"
         Write-Output "BRANCH: $($paths.CURRENT_BRANCH)"
         Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
@@ -114,36 +113,35 @@ if (Test-Path $paths.RESEARCH) { $docs += 'research.md' }
 if (Test-Path $paths.DATA_MODEL) { $docs += 'data-model.md' }
 
 # Check contracts directory (only if it exists and has files)
-if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) {
-    $docs += 'contracts/'
+if ((Test-Path $paths.CONTRACTS_DIR) -and (Get-ChildItem -Path $paths.CONTRACTS_DIR -ErrorAction SilentlyContinue | Select-Object -First 1)) { 
+    $docs += 'contracts/' 
 }
 
 if (Test-Path $paths.QUICKSTART) { $docs += 'quickstart.md' }
 
 # Include tasks.md if requested and it exists
-if ($IncludeTasks -and (Test-Path $paths.TASKS)) {
-    $docs += 'tasks.md'
+if ($IncludeTasks -and (Test-Path $paths.TASKS)) { 
+    $docs += 'tasks.md' 
 }
 
 # Output results
 if ($Json) {
     # JSON output
-    [PSCustomObject]@{
-        FEATURE_DIR    = $paths.FEATURE_DIR
-        AVAILABLE_DOCS = $docs
+    [PSCustomObject]@{ 
+        FEATURE_DIR = $paths.FEATURE_DIR
+        AVAILABLE_DOCS = $docs 
     } | ConvertTo-Json -Compress
-}
-else {
+} else {
     # Text output
     Write-Output "FEATURE_DIR:$($paths.FEATURE_DIR)"
     Write-Output "AVAILABLE_DOCS:"
-
+    
     # Show status of each potential document
     Test-FileExists -Path $paths.RESEARCH -Description 'research.md' | Out-Null
     Test-FileExists -Path $paths.DATA_MODEL -Description 'data-model.md' | Out-Null
     Test-DirHasFiles -Path $paths.CONTRACTS_DIR -Description 'contracts/' | Out-Null
     Test-FileExists -Path $paths.QUICKSTART -Description 'quickstart.md' | Out-Null
-
+    
     if ($IncludeTasks) {
         Test-FileExists -Path $paths.TASKS -Description 'tasks.md' | Out-Null
     }

--- a/.specify/scripts/powershell/check-prerequisites.ps1
+++ b/.specify/scripts/powershell/check-prerequisites.ps1
@@ -74,7 +74,8 @@ if ($PathsOnly) {
             IMPL_PLAN    = $paths.IMPL_PLAN
             TASKS        = $paths.TASKS
         } | ConvertTo-Json -Compress
-    } else {
+    }
+    else {
         Write-Output "REPO_ROOT: $($paths.REPO_ROOT)"
         Write-Output "BRANCH: $($paths.CURRENT_BRANCH)"
         Write-Output "FEATURE_DIR: $($paths.FEATURE_DIR)"
@@ -128,10 +129,11 @@ if ($IncludeTasks -and (Test-Path $paths.TASKS)) {
 if ($Json) {
     # JSON output
     [PSCustomObject]@{ 
-        FEATURE_DIR = $paths.FEATURE_DIR
+        FEATURE_DIR    = $paths.FEATURE_DIR
         AVAILABLE_DOCS = $docs 
     } | ConvertTo-Json -Compress
-} else {
+}
+else {
     # Text output
     Write-Output "FEATURE_DIR:$($paths.FEATURE_DIR)"
     Write-Output "AVAILABLE_DOCS:"

--- a/.specify/scripts/powershell/common.ps1
+++ b/.specify/scripts/powershell/common.ps1
@@ -11,7 +11,7 @@ function Get-RepoRoot {
     catch {
         # Git command failed
     }
-    
+
     # Fall back to script location for non-git repos
     return (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
 }
@@ -21,7 +21,7 @@ function Get-CurrentBranch {
     if ($env:SPECIFY_FEATURE) {
         return $env:SPECIFY_FEATURE
     }
-    
+
     # Then check git if available
     try {
         $result = git rev-parse --abbrev-ref HEAD 2>$null
@@ -32,15 +32,15 @@ function Get-CurrentBranch {
     catch {
         # Git command failed
     }
-    
+
     # For non-git repos, try to find the latest feature directory
     $repoRoot = Get-RepoRoot
     $specsDir = Join-Path $repoRoot "specs"
-    
+
     if (Test-Path $specsDir) {
         $latestFeature = ""
         $highest = 0
-        
+
         Get-ChildItem -Path $specsDir -Directory | ForEach-Object {
             if ($_.Name -match '^(\d{3})-') {
                 $num = [int]$matches[1]
@@ -50,12 +50,12 @@ function Get-CurrentBranch {
                 }
             }
         }
-        
+
         if ($latestFeature) {
             return $latestFeature
         }
     }
-    
+
     # Final fallback
     return "main"
 }
@@ -75,13 +75,13 @@ function Test-FeatureBranch {
         [string]$Branch,
         [bool]$HasGit = $true
     )
-    
+
     # For non-git repos, we can't enforce branch naming but still provide output
     if (-not $HasGit) {
         Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
         return $true
     }
-    
+
     if ($Branch -notmatch '^[0-9]{3}-') {
         Write-Output "ERROR: Not on a feature branch. Current branch: $Branch"
         Write-Output "Feature branches should be named like: 001-feature-name"
@@ -100,7 +100,7 @@ function Get-FeaturePathsEnv {
     $currentBranch = Get-CurrentBranch
     $hasGit = Test-HasGit
     $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
-    
+
     [PSCustomObject]@{
         REPO_ROOT      = $repoRoot
         CURRENT_BRANCH = $currentBranch
@@ -168,8 +168,8 @@ function Resolve-Template {
                 $presets = $registryData.presets
                 if ($presets) {
                     $sortedPresets = $presets.PSObject.Properties |
-                    Sort-Object { if ($null -ne $_.Value.priority) { $_.Value.priority } else { 10 } } |
-                    ForEach-Object { $_.Name }
+                        Sort-Object { if ($null -ne $_.Value.priority) { $_.Value.priority } else { 10 } } |
+                        ForEach-Object { $_.Name }
                 }
             }
             catch {
@@ -208,4 +208,3 @@ function Resolve-Template {
 
     return $null
 }
-

--- a/.specify/scripts/powershell/common.ps1
+++ b/.specify/scripts/powershell/common.ps1
@@ -7,7 +7,8 @@ function Get-RepoRoot {
         if ($LASTEXITCODE -eq 0) {
             return $result
         }
-    } catch {
+    }
+    catch {
         # Git command failed
     }
     
@@ -27,7 +28,8 @@ function Get-CurrentBranch {
         if ($LASTEXITCODE -eq 0) {
             return $result
         }
-    } catch {
+    }
+    catch {
         # Git command failed
     }
     
@@ -62,7 +64,8 @@ function Test-HasGit {
     try {
         git rev-parse --show-toplevel 2>$null | Out-Null
         return ($LASTEXITCODE -eq 0)
-    } catch {
+    }
+    catch {
         return $false
     }
 }
@@ -99,17 +102,17 @@ function Get-FeaturePathsEnv {
     $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
     
     [PSCustomObject]@{
-        REPO_ROOT     = $repoRoot
+        REPO_ROOT      = $repoRoot
         CURRENT_BRANCH = $currentBranch
-        HAS_GIT       = $hasGit
-        FEATURE_DIR   = $featureDir
-        FEATURE_SPEC  = Join-Path $featureDir 'spec.md'
-        IMPL_PLAN     = Join-Path $featureDir 'plan.md'
-        TASKS         = Join-Path $featureDir 'tasks.md'
-        RESEARCH      = Join-Path $featureDir 'research.md'
-        DATA_MODEL    = Join-Path $featureDir 'data-model.md'
-        QUICKSTART    = Join-Path $featureDir 'quickstart.md'
-        CONTRACTS_DIR = Join-Path $featureDir 'contracts'
+        HAS_GIT        = $hasGit
+        FEATURE_DIR    = $featureDir
+        FEATURE_SPEC   = Join-Path $featureDir 'spec.md'
+        IMPL_PLAN      = Join-Path $featureDir 'plan.md'
+        TASKS          = Join-Path $featureDir 'tasks.md'
+        RESEARCH       = Join-Path $featureDir 'research.md'
+        DATA_MODEL     = Join-Path $featureDir 'data-model.md'
+        QUICKSTART     = Join-Path $featureDir 'quickstart.md'
+        CONTRACTS_DIR  = Join-Path $featureDir 'contracts'
     }
 }
 
@@ -118,7 +121,8 @@ function Test-FileExists {
     if (Test-Path -Path $Path -PathType Leaf) {
         Write-Output "  ✓ $Description"
         return $true
-    } else {
+    }
+    else {
         Write-Output "  ✗ $Description"
         return $false
     }
@@ -129,7 +133,8 @@ function Test-DirHasFiles {
     if ((Test-Path -Path $Path -PathType Container) -and (Get-ChildItem -Path $Path -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | Select-Object -First 1)) {
         Write-Output "  ✓ $Description"
         return $true
-    } else {
+    }
+    else {
         Write-Output "  ✗ $Description"
         return $false
     }
@@ -142,8 +147,8 @@ function Test-DirHasFiles {
 #   4. .specify/templates/ (core)
 function Resolve-Template {
     param(
-        [Parameter(Mandatory=$true)][string]$TemplateName,
-        [Parameter(Mandatory=$true)][string]$RepoRoot
+        [Parameter(Mandatory = $true)][string]$TemplateName,
+        [Parameter(Mandatory = $true)][string]$RepoRoot
     )
 
     $base = Join-Path $RepoRoot '.specify/templates'
@@ -163,10 +168,11 @@ function Resolve-Template {
                 $presets = $registryData.presets
                 if ($presets) {
                     $sortedPresets = $presets.PSObject.Properties |
-                        Sort-Object { if ($null -ne $_.Value.priority) { $_.Value.priority } else { 10 } } |
-                        ForEach-Object { $_.Name }
+                    Sort-Object { if ($null -ne $_.Value.priority) { $_.Value.priority } else { 10 } } |
+                    ForEach-Object { $_.Name }
                 }
-            } catch {
+            }
+            catch {
                 # Fallback: alphabetical directory order
                 $sortedPresets = @()
             }
@@ -177,7 +183,8 @@ function Resolve-Template {
                 $candidate = Join-Path $presetsDir "$presetId/templates/$TemplateName.md"
                 if (Test-Path $candidate) { return $candidate }
             }
-        } else {
+        }
+        else {
             # Fallback: alphabetical directory order
             foreach ($preset in Get-ChildItem -Path $presetsDir -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -notlike '.*' }) {
                 $candidate = Join-Path $preset.FullName "templates/$TemplateName.md"

--- a/.specify/scripts/powershell/common.ps1
+++ b/.specify/scripts/powershell/common.ps1
@@ -7,11 +7,10 @@ function Get-RepoRoot {
         if ($LASTEXITCODE -eq 0) {
             return $result
         }
-    }
-    catch {
+    } catch {
         # Git command failed
     }
-
+    
     # Fall back to script location for non-git repos
     return (Resolve-Path (Join-Path $PSScriptRoot "../../..")).Path
 }
@@ -21,26 +20,25 @@ function Get-CurrentBranch {
     if ($env:SPECIFY_FEATURE) {
         return $env:SPECIFY_FEATURE
     }
-
+    
     # Then check git if available
     try {
         $result = git rev-parse --abbrev-ref HEAD 2>$null
         if ($LASTEXITCODE -eq 0) {
             return $result
         }
-    }
-    catch {
+    } catch {
         # Git command failed
     }
-
+    
     # For non-git repos, try to find the latest feature directory
     $repoRoot = Get-RepoRoot
     $specsDir = Join-Path $repoRoot "specs"
-
+    
     if (Test-Path $specsDir) {
         $latestFeature = ""
         $highest = 0
-
+        
         Get-ChildItem -Path $specsDir -Directory | ForEach-Object {
             if ($_.Name -match '^(\d{3})-') {
                 $num = [int]$matches[1]
@@ -50,12 +48,12 @@ function Get-CurrentBranch {
                 }
             }
         }
-
+        
         if ($latestFeature) {
             return $latestFeature
         }
     }
-
+    
     # Final fallback
     return "main"
 }
@@ -64,8 +62,7 @@ function Test-HasGit {
     try {
         git rev-parse --show-toplevel 2>$null | Out-Null
         return ($LASTEXITCODE -eq 0)
-    }
-    catch {
+    } catch {
         return $false
     }
 }
@@ -75,13 +72,13 @@ function Test-FeatureBranch {
         [string]$Branch,
         [bool]$HasGit = $true
     )
-
+    
     # For non-git repos, we can't enforce branch naming but still provide output
     if (-not $HasGit) {
         Write-Warning "[specify] Warning: Git repository not detected; skipped branch validation"
         return $true
     }
-
+    
     if ($Branch -notmatch '^[0-9]{3}-') {
         Write-Output "ERROR: Not on a feature branch. Current branch: $Branch"
         Write-Output "Feature branches should be named like: 001-feature-name"
@@ -100,19 +97,19 @@ function Get-FeaturePathsEnv {
     $currentBranch = Get-CurrentBranch
     $hasGit = Test-HasGit
     $featureDir = Get-FeatureDir -RepoRoot $repoRoot -Branch $currentBranch
-
+    
     [PSCustomObject]@{
-        REPO_ROOT      = $repoRoot
+        REPO_ROOT     = $repoRoot
         CURRENT_BRANCH = $currentBranch
-        HAS_GIT        = $hasGit
-        FEATURE_DIR    = $featureDir
-        FEATURE_SPEC   = Join-Path $featureDir 'spec.md'
-        IMPL_PLAN      = Join-Path $featureDir 'plan.md'
-        TASKS          = Join-Path $featureDir 'tasks.md'
-        RESEARCH       = Join-Path $featureDir 'research.md'
-        DATA_MODEL     = Join-Path $featureDir 'data-model.md'
-        QUICKSTART     = Join-Path $featureDir 'quickstart.md'
-        CONTRACTS_DIR  = Join-Path $featureDir 'contracts'
+        HAS_GIT       = $hasGit
+        FEATURE_DIR   = $featureDir
+        FEATURE_SPEC  = Join-Path $featureDir 'spec.md'
+        IMPL_PLAN     = Join-Path $featureDir 'plan.md'
+        TASKS         = Join-Path $featureDir 'tasks.md'
+        RESEARCH      = Join-Path $featureDir 'research.md'
+        DATA_MODEL    = Join-Path $featureDir 'data-model.md'
+        QUICKSTART    = Join-Path $featureDir 'quickstart.md'
+        CONTRACTS_DIR = Join-Path $featureDir 'contracts'
     }
 }
 
@@ -121,8 +118,7 @@ function Test-FileExists {
     if (Test-Path -Path $Path -PathType Leaf) {
         Write-Output "  ✓ $Description"
         return $true
-    }
-    else {
+    } else {
         Write-Output "  ✗ $Description"
         return $false
     }
@@ -133,10 +129,76 @@ function Test-DirHasFiles {
     if ((Test-Path -Path $Path -PathType Container) -and (Get-ChildItem -Path $Path -ErrorAction SilentlyContinue | Where-Object { -not $_.PSIsContainer } | Select-Object -First 1)) {
         Write-Output "  ✓ $Description"
         return $true
-    }
-    else {
+    } else {
         Write-Output "  ✗ $Description"
         return $false
     }
+}
+
+# Resolve a template name to a file path using the priority stack:
+#   1. .specify/templates/overrides/
+#   2. .specify/presets/<preset-id>/templates/ (sorted by priority from .registry)
+#   3. .specify/extensions/<ext-id>/templates/
+#   4. .specify/templates/ (core)
+function Resolve-Template {
+    param(
+        [Parameter(Mandatory=$true)][string]$TemplateName,
+        [Parameter(Mandatory=$true)][string]$RepoRoot
+    )
+
+    $base = Join-Path $RepoRoot '.specify/templates'
+
+    # Priority 1: Project overrides
+    $override = Join-Path $base "overrides/$TemplateName.md"
+    if (Test-Path $override) { return $override }
+
+    # Priority 2: Installed presets (sorted by priority from .registry)
+    $presetsDir = Join-Path $RepoRoot '.specify/presets'
+    if (Test-Path $presetsDir) {
+        $registryFile = Join-Path $presetsDir '.registry'
+        $sortedPresets = @()
+        if (Test-Path $registryFile) {
+            try {
+                $registryData = Get-Content $registryFile -Raw | ConvertFrom-Json
+                $presets = $registryData.presets
+                if ($presets) {
+                    $sortedPresets = $presets.PSObject.Properties |
+                        Sort-Object { if ($null -ne $_.Value.priority) { $_.Value.priority } else { 10 } } |
+                        ForEach-Object { $_.Name }
+                }
+            } catch {
+                # Fallback: alphabetical directory order
+                $sortedPresets = @()
+            }
+        }
+
+        if ($sortedPresets.Count -gt 0) {
+            foreach ($presetId in $sortedPresets) {
+                $candidate = Join-Path $presetsDir "$presetId/templates/$TemplateName.md"
+                if (Test-Path $candidate) { return $candidate }
+            }
+        } else {
+            # Fallback: alphabetical directory order
+            foreach ($preset in Get-ChildItem -Path $presetsDir -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -notlike '.*' }) {
+                $candidate = Join-Path $preset.FullName "templates/$TemplateName.md"
+                if (Test-Path $candidate) { return $candidate }
+            }
+        }
+    }
+
+    # Priority 3: Extension-provided templates
+    $extDir = Join-Path $RepoRoot '.specify/extensions'
+    if (Test-Path $extDir) {
+        foreach ($ext in Get-ChildItem -Path $extDir -Directory -ErrorAction SilentlyContinue | Where-Object { $_.Name -notlike '.*' } | Sort-Object Name) {
+            $candidate = Join-Path $ext.FullName "templates/$TemplateName.md"
+            if (Test-Path $candidate) { return $candidate }
+        }
+    }
+
+    # Priority 4: Core templates
+    $core = Join-Path $base "$TemplateName.md"
+    if (Test-Path $core) { return $core }
+
+    return $null
 }
 

--- a/.specify/scripts/powershell/create-new-feature.ps1
+++ b/.specify/scripts/powershell/create-new-feature.ps1
@@ -35,6 +35,12 @@ if (-not $FeatureDescription -or $FeatureDescription.Count -eq 0) {
 
 $featureDesc = ($FeatureDescription -join ' ').Trim()
 
+# Validate description is not empty after trimming (e.g., user passed only whitespace)
+if ([string]::IsNullOrWhiteSpace($featureDesc)) {
+    Write-Error "Error: Feature description cannot be empty or contain only whitespace"
+    exit 1
+}
+
 # Resolve repository root. Prefer git information when available, but fall back
 # to searching for repository markers so the workflow still functions in repositories that
 # were initialized with --no-git.
@@ -61,7 +67,7 @@ function Find-RepositoryRoot {
 
 function Get-HighestNumberFromSpecs {
     param([string]$SpecsDir)
-
+    
     $highest = 0
     if (Test-Path $SpecsDir) {
         Get-ChildItem -Path $SpecsDir -Directory | ForEach-Object {
@@ -76,7 +82,7 @@ function Get-HighestNumberFromSpecs {
 
 function Get-HighestNumberFromBranches {
     param()
-
+    
     $highest = 0
     try {
         $branches = git branch -a 2>$null
@@ -84,7 +90,7 @@ function Get-HighestNumberFromBranches {
             foreach ($branch in $branches) {
                 # Clean branch name: remove leading markers and remote prefixes
                 $cleanBranch = $branch.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
-
+                
                 # Extract feature number if branch matches pattern ###-*
                 if ($cleanBranch -match '^(\d+)-') {
                     $num = [int]$matches[1]
@@ -92,8 +98,7 @@ function Get-HighestNumberFromBranches {
                 }
             }
         }
-    }
-    catch {
+    } catch {
         # If git command fails, return 0
         Write-Verbose "Could not check Git branches: $_"
     }
@@ -108,8 +113,7 @@ function Get-NextBranchNumber {
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
     try {
         git fetch --all --prune 2>$null | Out-Null
-    }
-    catch {
+    } catch {
         # Ignore fetch errors
     }
 
@@ -128,7 +132,7 @@ function Get-NextBranchNumber {
 
 function ConvertTo-CleanBranchName {
     param([string]$Name)
-
+    
     return $Name.ToLower() -replace '[^a-z0-9]', '-' -replace '-{2,}', '-' -replace '^-', '' -replace '-$', ''
 }
 $fallbackRoot = (Find-RepositoryRoot -StartDir $PSScriptRoot)
@@ -137,16 +141,17 @@ if (-not $fallbackRoot) {
     exit 1
 }
 
+# Load common functions (includes Resolve-Template)
+. "$PSScriptRoot/common.ps1"
+
 try {
     $repoRoot = git rev-parse --show-toplevel 2>$null
     if ($LASTEXITCODE -eq 0) {
         $hasGit = $true
-    }
-    else {
+    } else {
         throw "Git not available"
     }
-}
-catch {
+} catch {
     $repoRoot = $fallbackRoot
     $hasGit = $false
 }
@@ -159,7 +164,7 @@ New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 # Function to generate branch name with stop word filtering and length filtering
 function Get-BranchName {
     param([string]$Description)
-
+    
     # Common stop words to filter out
     $stopWords = @(
         'i', 'a', 'an', 'the', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
@@ -168,34 +173,32 @@ function Get-BranchName {
         'this', 'that', 'these', 'those', 'my', 'your', 'our', 'their',
         'want', 'need', 'add', 'get', 'set'
     )
-
+    
     # Convert to lowercase and extract words (alphanumeric only)
     $cleanName = $Description.ToLower() -replace '[^a-z0-9\s]', ' '
     $words = $cleanName -split '\s+' | Where-Object { $_ }
-
+    
     # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
     $meaningfulWords = @()
     foreach ($word in $words) {
         # Skip stop words
         if ($stopWords -contains $word) { continue }
-
+        
         # Keep words that are length >= 3 OR appear as uppercase in original (likely acronyms)
         if ($word.Length -ge 3) {
             $meaningfulWords += $word
-        }
-        elseif ($Description -match "\b$($word.ToUpper())\b") {
+        } elseif ($Description -match "\b$($word.ToUpper())\b") {
             # Keep short words if they appear as uppercase in original (likely acronyms)
             $meaningfulWords += $word
         }
     }
-
+    
     # If we have meaningful words, use first 3-4 of them
     if ($meaningfulWords.Count -gt 0) {
         $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
         $result = ($meaningfulWords | Select-Object -First $maxWords) -join '-'
         return $result
-    }
-    else {
+    } else {
         # Fallback to original logic if no meaningful words found
         $result = ConvertTo-CleanBranchName -Name $Description
         $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
@@ -207,8 +210,7 @@ function Get-BranchName {
 if ($ShortName) {
     # Use provided short name, just clean it up
     $branchSuffix = ConvertTo-CleanBranchName -Name $ShortName
-}
-else {
+} else {
     # Generate from description with smart filtering
     $branchSuffix = Get-BranchName -Description $featureDesc
 }
@@ -218,8 +220,7 @@ if ($Number -eq 0) {
     if ($hasGit) {
         # Check existing branches on remotes
         $Number = Get-NextBranchNumber -SpecsDir $specsDir
-    }
-    else {
+    } else {
         # Fall back to local directory check
         $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
     }
@@ -235,57 +236,69 @@ if ($branchName.Length -gt $maxBranchLength) {
     # Calculate how much we need to trim from suffix
     # Account for: feature number (3) + hyphen (1) = 4 chars
     $maxSuffixLength = $maxBranchLength - 4
-
+    
     # Truncate suffix
     $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
     # Remove trailing hyphen if truncation created one
     $truncatedSuffix = $truncatedSuffix -replace '-$', ''
-
+    
     $originalBranchName = $branchName
     $branchName = "$featureNum-$truncatedSuffix"
-
+    
     Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
     Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"
     Write-Warning "[specify] Truncated to: $branchName ($($branchName.Length) bytes)"
 }
 
 if ($hasGit) {
+    $branchCreated = $false
     try {
-        git checkout -b $branchName | Out-Null
+        git checkout -q -b $branchName 2>$null | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            $branchCreated = $true
+        }
+    } catch {
+        # Exception during git command
     }
-    catch {
-        Write-Warning "Failed to create git branch: $branchName"
+
+    if (-not $branchCreated) {
+        # Check if branch already exists
+        $existingBranch = git branch --list $branchName 2>$null
+        if ($existingBranch) {
+            Write-Error "Error: Branch '$branchName' already exists. Please use a different feature name or specify a different number with -Number."
+            exit 1
+        } else {
+            Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
+            exit 1
+        }
     }
-}
-else {
+} else {
     Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
 }
 
 $featureDir = Join-Path $specsDir $branchName
 New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
 
-$template = Join-Path $repoRoot '.specify/templates/spec-template.md'
+$template = Resolve-Template -TemplateName 'spec-template' -RepoRoot $repoRoot
 $specFile = Join-Path $featureDir 'spec.md'
-if (Test-Path $template) {
-    Copy-Item $template $specFile -Force
-}
-else {
-    New-Item -ItemType File -Path $specFile | Out-Null
+if ($template -and (Test-Path $template)) { 
+    Copy-Item $template $specFile -Force 
+} else { 
+    New-Item -ItemType File -Path $specFile | Out-Null 
 }
 
 # Set the SPECIFY_FEATURE environment variable for the current session
 $env:SPECIFY_FEATURE = $branchName
 
 if ($Json) {
-    $obj = [PSCustomObject]@{
+    $obj = [PSCustomObject]@{ 
         BRANCH_NAME = $branchName
-        SPEC_FILE   = $specFile
+        SPEC_FILE = $specFile
         FEATURE_NUM = $featureNum
-        HAS_GIT     = $hasGit
+        HAS_GIT = $hasGit
     }
     $obj | ConvertTo-Json -Compress
-}
-else {
+} else {
     Write-Output "BRANCH_NAME: $branchName"
     Write-Output "SPEC_FILE: $specFile"
     Write-Output "FEATURE_NUM: $featureNum"

--- a/.specify/scripts/powershell/create-new-feature.ps1
+++ b/.specify/scripts/powershell/create-new-feature.ps1
@@ -98,7 +98,8 @@ function Get-HighestNumberFromBranches {
                 }
             }
         }
-    } catch {
+    }
+    catch {
         # If git command fails, return 0
         Write-Verbose "Could not check Git branches: $_"
     }
@@ -113,7 +114,8 @@ function Get-NextBranchNumber {
     # Fetch all remotes to get latest branch info (suppress errors if no remotes)
     try {
         git fetch --all --prune 2>$null | Out-Null
-    } catch {
+    }
+    catch {
         # Ignore fetch errors
     }
 
@@ -148,10 +150,12 @@ try {
     $repoRoot = git rev-parse --show-toplevel 2>$null
     if ($LASTEXITCODE -eq 0) {
         $hasGit = $true
-    } else {
+    }
+    else {
         throw "Git not available"
     }
-} catch {
+}
+catch {
     $repoRoot = $fallbackRoot
     $hasGit = $false
 }
@@ -187,7 +191,8 @@ function Get-BranchName {
         # Keep words that are length >= 3 OR appear as uppercase in original (likely acronyms)
         if ($word.Length -ge 3) {
             $meaningfulWords += $word
-        } elseif ($Description -match "\b$($word.ToUpper())\b") {
+        }
+        elseif ($Description -match "\b$($word.ToUpper())\b") {
             # Keep short words if they appear as uppercase in original (likely acronyms)
             $meaningfulWords += $word
         }
@@ -198,7 +203,8 @@ function Get-BranchName {
         $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
         $result = ($meaningfulWords | Select-Object -First $maxWords) -join '-'
         return $result
-    } else {
+    }
+    else {
         # Fallback to original logic if no meaningful words found
         $result = ConvertTo-CleanBranchName -Name $Description
         $fallbackWords = ($result -split '-') | Where-Object { $_ } | Select-Object -First 3
@@ -210,7 +216,8 @@ function Get-BranchName {
 if ($ShortName) {
     # Use provided short name, just clean it up
     $branchSuffix = ConvertTo-CleanBranchName -Name $ShortName
-} else {
+}
+else {
     # Generate from description with smart filtering
     $branchSuffix = Get-BranchName -Description $featureDesc
 }
@@ -220,7 +227,8 @@ if ($Number -eq 0) {
     if ($hasGit) {
         # Check existing branches on remotes
         $Number = Get-NextBranchNumber -SpecsDir $specsDir
-    } else {
+    }
+    else {
         # Fall back to local directory check
         $Number = (Get-HighestNumberFromSpecs -SpecsDir $specsDir) + 1
     }
@@ -257,7 +265,8 @@ if ($hasGit) {
         if ($LASTEXITCODE -eq 0) {
             $branchCreated = $true
         }
-    } catch {
+    }
+    catch {
         # Exception during git command
     }
 
@@ -267,12 +276,14 @@ if ($hasGit) {
         if ($existingBranch) {
             Write-Error "Error: Branch '$branchName' already exists. Please use a different feature name or specify a different number with -Number."
             exit 1
-        } else {
+        }
+        else {
             Write-Error "Error: Failed to create git branch '$branchName'. Please check your git configuration and try again."
             exit 1
         }
     }
-} else {
+}
+else {
     Write-Warning "[specify] Warning: Git repository not detected; skipped branch creation for $branchName"
 }
 
@@ -283,7 +294,8 @@ $template = Resolve-Template -TemplateName 'spec-template' -RepoRoot $repoRoot
 $specFile = Join-Path $featureDir 'spec.md'
 if ($template -and (Test-Path $template)) { 
     Copy-Item $template $specFile -Force 
-} else { 
+}
+else { 
     New-Item -ItemType File -Path $specFile | Out-Null 
 }
 
@@ -293,12 +305,13 @@ $env:SPECIFY_FEATURE = $branchName
 if ($Json) {
     $obj = [PSCustomObject]@{ 
         BRANCH_NAME = $branchName
-        SPEC_FILE = $specFile
+        SPEC_FILE   = $specFile
         FEATURE_NUM = $featureNum
-        HAS_GIT = $hasGit
+        HAS_GIT     = $hasGit
     }
     $obj | ConvertTo-Json -Compress
-} else {
+}
+else {
     Write-Output "BRANCH_NAME: $branchName"
     Write-Output "SPEC_FILE: $specFile"
     Write-Output "FEATURE_NUM: $featureNum"

--- a/.specify/scripts/powershell/create-new-feature.ps1
+++ b/.specify/scripts/powershell/create-new-feature.ps1
@@ -67,7 +67,7 @@ function Find-RepositoryRoot {
 
 function Get-HighestNumberFromSpecs {
     param([string]$SpecsDir)
-    
+
     $highest = 0
     if (Test-Path $SpecsDir) {
         Get-ChildItem -Path $SpecsDir -Directory | ForEach-Object {
@@ -82,7 +82,7 @@ function Get-HighestNumberFromSpecs {
 
 function Get-HighestNumberFromBranches {
     param()
-    
+
     $highest = 0
     try {
         $branches = git branch -a 2>$null
@@ -90,7 +90,7 @@ function Get-HighestNumberFromBranches {
             foreach ($branch in $branches) {
                 # Clean branch name: remove leading markers and remote prefixes
                 $cleanBranch = $branch.Trim() -replace '^\*?\s+', '' -replace '^remotes/[^/]+/', ''
-                
+
                 # Extract feature number if branch matches pattern ###-*
                 if ($cleanBranch -match '^(\d+)-') {
                     $num = [int]$matches[1]
@@ -134,7 +134,7 @@ function Get-NextBranchNumber {
 
 function ConvertTo-CleanBranchName {
     param([string]$Name)
-    
+
     return $Name.ToLower() -replace '[^a-z0-9]', '-' -replace '-{2,}', '-' -replace '^-', '' -replace '-$', ''
 }
 $fallbackRoot = (Find-RepositoryRoot -StartDir $PSScriptRoot)
@@ -168,7 +168,7 @@ New-Item -ItemType Directory -Path $specsDir -Force | Out-Null
 # Function to generate branch name with stop word filtering and length filtering
 function Get-BranchName {
     param([string]$Description)
-    
+
     # Common stop words to filter out
     $stopWords = @(
         'i', 'a', 'an', 'the', 'to', 'for', 'of', 'in', 'on', 'at', 'by', 'with', 'from',
@@ -177,17 +177,17 @@ function Get-BranchName {
         'this', 'that', 'these', 'those', 'my', 'your', 'our', 'their',
         'want', 'need', 'add', 'get', 'set'
     )
-    
+
     # Convert to lowercase and extract words (alphanumeric only)
     $cleanName = $Description.ToLower() -replace '[^a-z0-9\s]', ' '
     $words = $cleanName -split '\s+' | Where-Object { $_ }
-    
+
     # Filter words: remove stop words and words shorter than 3 chars (unless they're uppercase acronyms in original)
     $meaningfulWords = @()
     foreach ($word in $words) {
         # Skip stop words
         if ($stopWords -contains $word) { continue }
-        
+
         # Keep words that are length >= 3 OR appear as uppercase in original (likely acronyms)
         if ($word.Length -ge 3) {
             $meaningfulWords += $word
@@ -197,7 +197,7 @@ function Get-BranchName {
             $meaningfulWords += $word
         }
     }
-    
+
     # If we have meaningful words, use first 3-4 of them
     if ($meaningfulWords.Count -gt 0) {
         $maxWords = if ($meaningfulWords.Count -eq 4) { 4 } else { 3 }
@@ -244,15 +244,15 @@ if ($branchName.Length -gt $maxBranchLength) {
     # Calculate how much we need to trim from suffix
     # Account for: feature number (3) + hyphen (1) = 4 chars
     $maxSuffixLength = $maxBranchLength - 4
-    
+
     # Truncate suffix
     $truncatedSuffix = $branchSuffix.Substring(0, [Math]::Min($branchSuffix.Length, $maxSuffixLength))
     # Remove trailing hyphen if truncation created one
     $truncatedSuffix = $truncatedSuffix -replace '-$', ''
-    
+
     $originalBranchName = $branchName
     $branchName = "$featureNum-$truncatedSuffix"
-    
+
     Write-Warning "[specify] Branch name exceeded GitHub's 244-byte limit"
     Write-Warning "[specify] Original: $originalBranchName ($($originalBranchName.Length) bytes)"
     Write-Warning "[specify] Truncated to: $branchName ($($branchName.Length) bytes)"
@@ -292,18 +292,18 @@ New-Item -ItemType Directory -Path $featureDir -Force | Out-Null
 
 $template = Resolve-Template -TemplateName 'spec-template' -RepoRoot $repoRoot
 $specFile = Join-Path $featureDir 'spec.md'
-if ($template -and (Test-Path $template)) { 
-    Copy-Item $template $specFile -Force 
+if ($template -and (Test-Path $template)) {
+    Copy-Item $template $specFile -Force
 }
-else { 
-    New-Item -ItemType File -Path $specFile | Out-Null 
+else {
+    New-Item -ItemType File -Path $specFile | Out-Null
 }
 
 # Set the SPECIFY_FEATURE environment variable for the current session
 $env:SPECIFY_FEATURE = $branchName
 
 if ($Json) {
-    $obj = [PSCustomObject]@{ 
+    $obj = [PSCustomObject]@{
         BRANCH_NAME = $branchName
         SPEC_FILE   = $specFile
         FEATURE_NUM = $featureNum
@@ -318,4 +318,3 @@ else {
     Write-Output "HAS_GIT: $hasGit"
     Write-Output "SPECIFY_FEATURE environment variable set to: $branchName"
 }
-

--- a/.specify/scripts/powershell/setup-plan.ps1
+++ b/.specify/scripts/powershell/setup-plan.ps1
@@ -36,7 +36,8 @@ $template = Resolve-Template -TemplateName 'plan-template' -RepoRoot $paths.REPO
 if ($template -and (Test-Path $template)) { 
     Copy-Item $template $paths.IMPL_PLAN -Force
     Write-Output "Copied plan template to $($paths.IMPL_PLAN)"
-} else {
+}
+else {
     Write-Warning "Plan template not found"
     # Create a basic plan file if template doesn't exist
     New-Item -ItemType File -Path $paths.IMPL_PLAN -Force | Out-Null
@@ -46,13 +47,14 @@ if ($template -and (Test-Path $template)) {
 if ($Json) {
     $result = [PSCustomObject]@{ 
         FEATURE_SPEC = $paths.FEATURE_SPEC
-        IMPL_PLAN = $paths.IMPL_PLAN
-        SPECS_DIR = $paths.FEATURE_DIR
-        BRANCH = $paths.CURRENT_BRANCH
-        HAS_GIT = $paths.HAS_GIT
+        IMPL_PLAN    = $paths.IMPL_PLAN
+        SPECS_DIR    = $paths.FEATURE_DIR
+        BRANCH       = $paths.CURRENT_BRANCH
+        HAS_GIT      = $paths.HAS_GIT
     }
     $result | ConvertTo-Json -Compress
-} else {
+}
+else {
     Write-Output "FEATURE_SPEC: $($paths.FEATURE_SPEC)"
     Write-Output "IMPL_PLAN: $($paths.IMPL_PLAN)"
     Write-Output "SPECS_DIR: $($paths.FEATURE_DIR)"

--- a/.specify/scripts/powershell/setup-plan.ps1
+++ b/.specify/scripts/powershell/setup-plan.ps1
@@ -24,8 +24,8 @@ if ($Help) {
 $paths = Get-FeaturePathsEnv
 
 # Check if we're on a proper feature branch (only for git repos)
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) { 
-    exit 1 
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
+    exit 1
 }
 
 # Ensure the feature directory exists
@@ -33,7 +33,7 @@ New-Item -ItemType Directory -Path $paths.FEATURE_DIR -Force | Out-Null
 
 # Copy plan template if it exists, otherwise note it or create empty file
 $template = Resolve-Template -TemplateName 'plan-template' -RepoRoot $paths.REPO_ROOT
-if ($template -and (Test-Path $template)) { 
+if ($template -and (Test-Path $template)) {
     Copy-Item $template $paths.IMPL_PLAN -Force
     Write-Output "Copied plan template to $($paths.IMPL_PLAN)"
 }
@@ -45,7 +45,7 @@ else {
 
 # Output results
 if ($Json) {
-    $result = [PSCustomObject]@{ 
+    $result = [PSCustomObject]@{
         FEATURE_SPEC = $paths.FEATURE_SPEC
         IMPL_PLAN    = $paths.IMPL_PLAN
         SPECS_DIR    = $paths.FEATURE_DIR

--- a/.specify/scripts/powershell/setup-plan.ps1
+++ b/.specify/scripts/powershell/setup-plan.ps1
@@ -24,37 +24,35 @@ if ($Help) {
 $paths = Get-FeaturePathsEnv
 
 # Check if we're on a proper feature branch (only for git repos)
-if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) {
-    exit 1
+if (-not (Test-FeatureBranch -Branch $paths.CURRENT_BRANCH -HasGit $paths.HAS_GIT)) { 
+    exit 1 
 }
 
 # Ensure the feature directory exists
 New-Item -ItemType Directory -Path $paths.FEATURE_DIR -Force | Out-Null
 
 # Copy plan template if it exists, otherwise note it or create empty file
-$template = Join-Path $paths.REPO_ROOT '.specify/templates/plan-template.md'
-if (Test-Path $template) {
+$template = Resolve-Template -TemplateName 'plan-template' -RepoRoot $paths.REPO_ROOT
+if ($template -and (Test-Path $template)) { 
     Copy-Item $template $paths.IMPL_PLAN -Force
     Write-Output "Copied plan template to $($paths.IMPL_PLAN)"
-}
-else {
-    Write-Warning "Plan template not found at $template"
+} else {
+    Write-Warning "Plan template not found"
     # Create a basic plan file if template doesn't exist
     New-Item -ItemType File -Path $paths.IMPL_PLAN -Force | Out-Null
 }
 
 # Output results
 if ($Json) {
-    $result = [PSCustomObject]@{
+    $result = [PSCustomObject]@{ 
         FEATURE_SPEC = $paths.FEATURE_SPEC
-        IMPL_PLAN    = $paths.IMPL_PLAN
-        SPECS_DIR    = $paths.FEATURE_DIR
-        BRANCH       = $paths.CURRENT_BRANCH
-        HAS_GIT      = $paths.HAS_GIT
+        IMPL_PLAN = $paths.IMPL_PLAN
+        SPECS_DIR = $paths.FEATURE_DIR
+        BRANCH = $paths.CURRENT_BRANCH
+        HAS_GIT = $paths.HAS_GIT
     }
     $result | ConvertTo-Json -Compress
-}
-else {
+} else {
     Write-Output "FEATURE_SPEC: $($paths.FEATURE_SPEC)"
     Write-Output "IMPL_PLAN: $($paths.IMPL_PLAN)"
     Write-Output "SPECS_DIR: $($paths.FEATURE_DIR)"

--- a/.specify/scripts/powershell/update-agent-context.ps1
+++ b/.specify/scripts/powershell/update-agent-context.ps1
@@ -24,8 +24,8 @@ Optional agent key to update a single agent. If omitted, updates all existing ag
 Relies on common helper functions in common.ps1
 #>
 param(
-    [Parameter(Position=0)]
-    [ValidateSet('claude','gemini','copilot','cursor-agent','qwen','opencode','codex','windsurf','kilocode','auggie','roo','codebuddy','amp','shai','tabnine','kiro-cli','agy','bob','qodercli','vibe','kimi','generic')]
+    [Parameter(Position = 0)]
+    [ValidateSet('claude', 'gemini', 'copilot', 'cursor-agent', 'qwen', 'opencode', 'codex', 'windsurf', 'kilocode', 'auggie', 'roo', 'codebuddy', 'amp', 'shai', 'tabnine', 'kiro-cli', 'agy', 'bob', 'qodercli', 'vibe', 'kimi', 'generic')]
     [string]$AgentType
 )
 
@@ -37,33 +37,33 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Acquire environment paths
 $envData = Get-FeaturePathsEnv
-$REPO_ROOT     = $envData.REPO_ROOT
+$REPO_ROOT = $envData.REPO_ROOT
 $CURRENT_BRANCH = $envData.CURRENT_BRANCH
-$HAS_GIT       = $envData.HAS_GIT
-$IMPL_PLAN     = $envData.IMPL_PLAN
+$HAS_GIT = $envData.HAS_GIT
+$IMPL_PLAN = $envData.IMPL_PLAN
 $NEW_PLAN = $IMPL_PLAN
 
 # Agent file paths
-$CLAUDE_FILE   = Join-Path $REPO_ROOT 'CLAUDE.md'
-$GEMINI_FILE   = Join-Path $REPO_ROOT 'GEMINI.md'
-$COPILOT_FILE  = Join-Path $REPO_ROOT '.github/agents/copilot-instructions.md'
-$CURSOR_FILE   = Join-Path $REPO_ROOT '.cursor/rules/specify-rules.mdc'
-$QWEN_FILE     = Join-Path $REPO_ROOT 'QWEN.md'
-$AGENTS_FILE   = Join-Path $REPO_ROOT 'AGENTS.md'
+$CLAUDE_FILE = Join-Path $REPO_ROOT 'CLAUDE.md'
+$GEMINI_FILE = Join-Path $REPO_ROOT 'GEMINI.md'
+$COPILOT_FILE = Join-Path $REPO_ROOT '.github/agents/copilot-instructions.md'
+$CURSOR_FILE = Join-Path $REPO_ROOT '.cursor/rules/specify-rules.mdc'
+$QWEN_FILE = Join-Path $REPO_ROOT 'QWEN.md'
+$AGENTS_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
 $WINDSURF_FILE = Join-Path $REPO_ROOT '.windsurf/rules/specify-rules.md'
 $KILOCODE_FILE = Join-Path $REPO_ROOT '.kilocode/rules/specify-rules.md'
-$AUGGIE_FILE   = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
-$ROO_FILE      = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
+$AUGGIE_FILE = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
+$ROO_FILE = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
 $CODEBUDDY_FILE = Join-Path $REPO_ROOT 'CODEBUDDY.md'
-$QODER_FILE    = Join-Path $REPO_ROOT 'QODER.md'
-$AMP_FILE      = Join-Path $REPO_ROOT 'AGENTS.md'
-$SHAI_FILE     = Join-Path $REPO_ROOT 'SHAI.md'
-$TABNINE_FILE  = Join-Path $REPO_ROOT 'TABNINE.md'
-$KIRO_FILE     = Join-Path $REPO_ROOT 'AGENTS.md'
-$AGY_FILE      = Join-Path $REPO_ROOT '.agent/rules/specify-rules.md'
-$BOB_FILE      = Join-Path $REPO_ROOT 'AGENTS.md'
-$VIBE_FILE     = Join-Path $REPO_ROOT '.vibe/agents/specify-agents.md'
-$KIMI_FILE     = Join-Path $REPO_ROOT 'KIMI.md'
+$QODER_FILE = Join-Path $REPO_ROOT 'QODER.md'
+$AMP_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
+$SHAI_FILE = Join-Path $REPO_ROOT 'SHAI.md'
+$TABNINE_FILE = Join-Path $REPO_ROOT 'TABNINE.md'
+$KIRO_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
+$AGY_FILE = Join-Path $REPO_ROOT '.agent/rules/specify-rules.md'
+$BOB_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
+$VIBE_FILE = Join-Path $REPO_ROOT '.vibe/agents/specify-agents.md'
+$KIMI_FILE = Join-Path $REPO_ROOT 'KIMI.md'
 
 $TEMPLATE_FILE = Join-Path $REPO_ROOT '.specify/templates/agent-file-template.md'
 
@@ -73,36 +73,36 @@ $script:NEW_FRAMEWORK = ''
 $script:NEW_DB = ''
 $script:NEW_PROJECT_TYPE = ''
 
-function Write-Info { 
+function Write-Info {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message
     )
-    Write-Host "INFO: $Message" 
+    Write-Host "INFO: $Message"
 }
 
-function Write-Success { 
+function Write-Success {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message
     )
-    Write-Host "$([char]0x2713) $Message" 
+    Write-Host "$([char]0x2713) $Message"
 }
 
-function Write-WarningMsg { 
+function Write-WarningMsg {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message
     )
-    Write-Warning $Message 
+    Write-Warning $Message
 }
 
-function Write-Err { 
+function Write-Err {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Message
     )
-    Write-Host "ERROR: $Message" -ForegroundColor Red 
+    Write-Host "ERROR: $Message" -ForegroundColor Red
 }
 
 function Validate-Environment {
@@ -126,32 +126,32 @@ function Validate-Environment {
 
 function Extract-PlanField {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$FieldPattern,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$PlanFile
     )
     if (-not (Test-Path $PlanFile)) { return '' }
     # Lines like **Language/Version**: Python 3.12
     $regex = "^\*\*$([Regex]::Escape($FieldPattern))\*\*: (.+)$"
     Get-Content -LiteralPath $PlanFile -Encoding utf8 | ForEach-Object {
-        if ($_ -match $regex) { 
+        if ($_ -match $regex) {
             $val = $Matches[1].Trim()
-            if ($val -notin @('NEEDS CLARIFICATION','N/A')) { return $val }
+            if ($val -notin @('NEEDS CLARIFICATION', 'N/A')) { return $val }
         }
     } | Select-Object -First 1
 }
 
 function Parse-PlanData {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$PlanFile
     )
     if (-not (Test-Path $PlanFile)) { Write-Err "Plan file not found: $PlanFile"; return $false }
     Write-Info "Parsing plan data from $PlanFile"
-    $script:NEW_LANG        = Extract-PlanField -FieldPattern 'Language/Version' -PlanFile $PlanFile
-    $script:NEW_FRAMEWORK   = Extract-PlanField -FieldPattern 'Primary Dependencies' -PlanFile $PlanFile
-    $script:NEW_DB          = Extract-PlanField -FieldPattern 'Storage' -PlanFile $PlanFile
+    $script:NEW_LANG = Extract-PlanField -FieldPattern 'Language/Version' -PlanFile $PlanFile
+    $script:NEW_FRAMEWORK = Extract-PlanField -FieldPattern 'Primary Dependencies' -PlanFile $PlanFile
+    $script:NEW_DB = Extract-PlanField -FieldPattern 'Storage' -PlanFile $PlanFile
     $script:NEW_PROJECT_TYPE = Extract-PlanField -FieldPattern 'Project Type' -PlanFile $PlanFile
 
     if ($NEW_LANG) { Write-Info "Found language: $NEW_LANG" } else { Write-WarningMsg 'No language information found in plan' }
@@ -163,29 +163,29 @@ function Parse-PlanData {
 
 function Format-TechnologyStack {
     param(
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$Lang,
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$Framework
     )
     $parts = @()
     if ($Lang -and $Lang -ne 'NEEDS CLARIFICATION') { $parts += $Lang }
-    if ($Framework -and $Framework -notin @('NEEDS CLARIFICATION','N/A')) { $parts += $Framework }
+    if ($Framework -and $Framework -notin @('NEEDS CLARIFICATION', 'N/A')) { $parts += $Framework }
     if (-not $parts) { return '' }
     return ($parts -join ' + ')
 }
 
-function Get-ProjectStructure { 
+function Get-ProjectStructure {
     param(
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$ProjectType
     )
-    if ($ProjectType -match 'web') { return "backend/`nfrontend/`ntests/" } else { return "src/`ntests/" } 
+    if ($ProjectType -match 'web') { return "backend/`nfrontend/`ntests/" } else { return "src/`ntests/" }
 }
 
-function Get-CommandsForLanguage { 
+function Get-CommandsForLanguage {
     param(
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$Lang
     )
     switch -Regex ($Lang) {
@@ -196,21 +196,21 @@ function Get-CommandsForLanguage {
     }
 }
 
-function Get-LanguageConventions { 
+function Get-LanguageConventions {
     param(
-        [Parameter(Mandatory=$false)]
+        [Parameter(Mandatory = $false)]
         [string]$Lang
     )
-    if ($Lang) { "${Lang}: Follow standard conventions" } else { 'General: Follow standard conventions' } 
+    if ($Lang) { "${Lang}: Follow standard conventions" } else { 'General: Follow standard conventions' }
 }
 
 function New-AgentFile {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$TargetFile,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$ProjectName,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [datetime]$Date
     )
     if (-not (Test-Path $TEMPLATE_FILE)) { Write-Err "Template not found at $TEMPLATE_FILE"; return $false }
@@ -226,44 +226,48 @@ function New-AgentFile {
     $escaped_branch = $CURRENT_BRANCH
 
     $content = Get-Content -LiteralPath $temp -Raw -Encoding utf8
-    $content = $content -replace '\[PROJECT NAME\]',$ProjectName
-    $content = $content -replace '\[DATE\]',$Date.ToString('yyyy-MM-dd')
-    
+    $content = $content -replace '\[PROJECT NAME\]', $ProjectName
+    $content = $content -replace '\[DATE\]', $Date.ToString('yyyy-MM-dd')
+
     # Build the technology stack string safely
     $techStackForTemplate = ""
     if ($escaped_lang -and $escaped_framework) {
         $techStackForTemplate = "- $escaped_lang + $escaped_framework ($escaped_branch)"
-    } elseif ($escaped_lang) {
+    }
+    elseif ($escaped_lang) {
         $techStackForTemplate = "- $escaped_lang ($escaped_branch)"
-    } elseif ($escaped_framework) {
+    }
+    elseif ($escaped_framework) {
         $techStackForTemplate = "- $escaped_framework ($escaped_branch)"
     }
-    
-    $content = $content -replace '\[EXTRACTED FROM ALL PLAN.MD FILES\]',$techStackForTemplate
+
+    $content = $content -replace '\[EXTRACTED FROM ALL PLAN.MD FILES\]', $techStackForTemplate
     # For project structure we manually embed (keep newlines)
     $escapedStructure = [Regex]::Escape($projectStructure)
-    $content = $content -replace '\[ACTUAL STRUCTURE FROM PLANS\]',$escapedStructure
+    $content = $content -replace '\[ACTUAL STRUCTURE FROM PLANS\]', $escapedStructure
     # Replace escaped newlines placeholder after all replacements
-    $content = $content -replace '\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]',$commands
-    $content = $content -replace '\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]',$languageConventions
-    
+    $content = $content -replace '\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]', $commands
+    $content = $content -replace '\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]', $languageConventions
+
     # Build the recent changes string safely
     $recentChangesForTemplate = ""
     if ($escaped_lang -and $escaped_framework) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_lang} + ${escaped_framework}"
-    } elseif ($escaped_lang) {
+    }
+    elseif ($escaped_lang) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_lang}"
-    } elseif ($escaped_framework) {
+    }
+    elseif ($escaped_framework) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_framework}"
     }
-    
-    $content = $content -replace '\[LAST 3 FEATURES AND WHAT THEY ADDED\]',$recentChangesForTemplate
+
+    $content = $content -replace '\[LAST 3 FEATURES AND WHAT THEY ADDED\]', $recentChangesForTemplate
     # Convert literal \n sequences introduced by Escape to real newlines
-    $content = $content -replace '\\n',[Environment]::NewLine
+    $content = $content -replace '\\n', [Environment]::NewLine
 
     # Prepend Cursor frontmatter for .mdc files so rules are auto-included
     if ($TargetFile -match '\.mdc$') {
-        $frontmatter = @('---','description: Project Development Guidelines','globs: ["**/*"]','alwaysApply: true','---','') -join [Environment]::NewLine
+        $frontmatter = @('---', 'description: Project Development Guidelines', 'globs: ["**/*"]', 'alwaysApply: true', '---', '') -join [Environment]::NewLine
         $content = $frontmatter + $content
     }
 
@@ -276,9 +280,9 @@ function New-AgentFile {
 
 function Update-ExistingAgentFile {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$TargetFile,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [datetime]$Date
     )
     if (-not (Test-Path $TargetFile)) { return (New-AgentFile -TargetFile $TargetFile -ProjectName (Split-Path $REPO_ROOT -Leaf) -Date $Date) }
@@ -287,25 +291,25 @@ function Update-ExistingAgentFile {
     $newTechEntries = @()
     if ($techStack) {
         $escapedTechStack = [Regex]::Escape($techStack)
-        if (-not (Select-String -Pattern $escapedTechStack -Path $TargetFile -Quiet)) { 
-            $newTechEntries += "- $techStack ($CURRENT_BRANCH)" 
+        if (-not (Select-String -Pattern $escapedTechStack -Path $TargetFile -Quiet)) {
+            $newTechEntries += "- $techStack ($CURRENT_BRANCH)"
         }
     }
-    if ($NEW_DB -and $NEW_DB -notin @('N/A','NEEDS CLARIFICATION')) {
+    if ($NEW_DB -and $NEW_DB -notin @('N/A', 'NEEDS CLARIFICATION')) {
         $escapedDB = [Regex]::Escape($NEW_DB)
-        if (-not (Select-String -Pattern $escapedDB -Path $TargetFile -Quiet)) { 
-            $newTechEntries += "- $NEW_DB ($CURRENT_BRANCH)" 
+        if (-not (Select-String -Pattern $escapedDB -Path $TargetFile -Quiet)) {
+            $newTechEntries += "- $NEW_DB ($CURRENT_BRANCH)"
         }
     }
     $newChangeEntry = ''
     if ($techStack) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${techStack}" }
-    elseif ($NEW_DB -and $NEW_DB -notin @('N/A','NEEDS CLARIFICATION')) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${NEW_DB}" }
+    elseif ($NEW_DB -and $NEW_DB -notin @('N/A', 'NEEDS CLARIFICATION')) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${NEW_DB}" }
 
     $lines = Get-Content -LiteralPath $TargetFile -Encoding utf8
     $output = New-Object System.Collections.Generic.List[string]
     $inTech = $false; $inChanges = $false; $techAdded = $false; $changeAdded = $false; $existingChanges = 0
 
-    for ($i=0; $i -lt $lines.Count; $i++) {
+    for ($i = 0; $i -lt $lines.Count; $i++) {
         $line = $lines[$i]
         if ($line -eq '## Active Technologies') {
             $output.Add($line)
@@ -332,7 +336,7 @@ function Update-ExistingAgentFile {
             continue
         }
         if ($line -match '(\*\*)?Last updated(\*\*)?: .*\d{4}-\d{2}-\d{2}') {
-            $output.Add(($line -replace '\d{4}-\d{2}-\d{2}',$Date.ToString('yyyy-MM-dd')))
+            $output.Add(($line -replace '\d{4}-\d{2}-\d{2}', $Date.ToString('yyyy-MM-dd')))
             continue
         }
         $output.Add($line)
@@ -345,7 +349,7 @@ function Update-ExistingAgentFile {
 
     # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
     if ($TargetFile -match '\.mdc$' -and $output.Count -gt 0 -and $output[0] -ne '---') {
-        $frontmatter = @('---','description: Project Development Guidelines','globs: ["**/*"]','alwaysApply: true','---','')
+        $frontmatter = @('---', 'description: Project Development Guidelines', 'globs: ["**/*"]', 'alwaysApply: true', '---', '')
         $output.InsertRange(0, $frontmatter)
     }
 
@@ -355,9 +359,9 @@ function Update-ExistingAgentFile {
 
 function Update-AgentFile {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$TargetFile,
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$AgentName
     )
     if (-not $TargetFile -or -not $AgentName) { Write-Err 'Update-AgentFile requires TargetFile and AgentName'; return $false }
@@ -370,10 +374,12 @@ function Update-AgentFile {
 
     if (-not (Test-Path $TargetFile)) {
         if (New-AgentFile -TargetFile $TargetFile -ProjectName $projectName -Date $date) { Write-Success "Created new $AgentName context file" } else { Write-Err 'Failed to create new agent file'; return $false }
-    } else {
+    }
+    else {
         try {
             if (Update-ExistingAgentFile -TargetFile $TargetFile -Date $date) { Write-Success "Updated existing $AgentName context file" } else { Write-Err 'Failed to update agent file'; return $false }
-        } catch {
+        }
+        catch {
             Write-Err "Cannot access or update existing file: $TargetFile. $_"
             return $false
         }
@@ -383,32 +389,32 @@ function Update-AgentFile {
 
 function Update-SpecificAgent {
     param(
-        [Parameter(Mandatory=$true)]
+        [Parameter(Mandatory = $true)]
         [string]$Type
     )
     switch ($Type) {
-        'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
-        'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
-        'copilot'  { Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot' }
+        'claude' { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
+        'gemini' { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
+        'copilot' { Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot' }
         'cursor-agent' { Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE' }
-        'qwen'     { Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code' }
+        'qwen' { Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code' }
         'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
-        'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
+        'codex' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
         'windsurf' { Update-AgentFile -TargetFile $WINDSURF_FILE -AgentName 'Windsurf' }
         'kilocode' { Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code' }
-        'auggie'   { Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI' }
-        'roo'      { Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code' }
+        'auggie' { Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI' }
+        'roo' { Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code' }
         'codebuddy' { Update-AgentFile -TargetFile $CODEBUDDY_FILE -AgentName 'CodeBuddy CLI' }
         'qodercli' { Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI' }
-        'amp'      { Update-AgentFile -TargetFile $AMP_FILE      -AgentName 'Amp' }
-        'shai'     { Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI' }
-        'tabnine'  { Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI' }
+        'amp' { Update-AgentFile -TargetFile $AMP_FILE      -AgentName 'Amp' }
+        'shai' { Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI' }
+        'tabnine' { Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI' }
         'kiro-cli' { Update-AgentFile -TargetFile $KIRO_FILE     -AgentName 'Kiro CLI' }
-        'agy'      { Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity' }
-        'bob'      { Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob' }
-        'vibe'     { Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe' }
-        'kimi'     { Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code' }
-        'generic'  { Write-Info 'Generic agent: no predefined context file. Use the agent-specific update script for your agent.' }
+        'agy' { Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity' }
+        'bob' { Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob' }
+        'vibe' { Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe' }
+        'kimi' { Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code' }
+        'generic' { Write-Info 'Generic agent: no predefined context file. Use the agent-specific update script for your agent.' }
         default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic'; return $false }
     }
 }
@@ -416,25 +422,25 @@ function Update-SpecificAgent {
 function Update-AllExistingAgents {
     $found = $false
     $ok = $true
-    if (Test-Path $CLAUDE_FILE)   { if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $GEMINI_FILE)   { if (-not (Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $COPILOT_FILE)  { if (-not (Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot')) { $ok = $false }; $found = $true }
-    if (Test-Path $CURSOR_FILE)   { if (-not (Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE')) { $ok = $false }; $found = $true }
-    if (Test-Path $QWEN_FILE)     { if (-not (Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $AGENTS_FILE)   { if (-not (Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex/opencode')) { $ok = $false }; $found = $true }
+    if (Test-Path $CLAUDE_FILE) { if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $GEMINI_FILE) { if (-not (Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $COPILOT_FILE) { if (-not (Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot')) { $ok = $false }; $found = $true }
+    if (Test-Path $CURSOR_FILE) { if (-not (Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE')) { $ok = $false }; $found = $true }
+    if (Test-Path $QWEN_FILE) { if (-not (Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $AGENTS_FILE) { if (-not (Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex/opencode')) { $ok = $false }; $found = $true }
     if (Test-Path $WINDSURF_FILE) { if (-not (Update-AgentFile -TargetFile $WINDSURF_FILE -AgentName 'Windsurf')) { $ok = $false }; $found = $true }
     if (Test-Path $KILOCODE_FILE) { if (-not (Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $AUGGIE_FILE)   { if (-not (Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $ROO_FILE)      { if (-not (Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $AUGGIE_FILE) { if (-not (Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $ROO_FILE) { if (-not (Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code')) { $ok = $false }; $found = $true }
     if (Test-Path $CODEBUDDY_FILE) { if (-not (Update-AgentFile -TargetFile $CODEBUDDY_FILE -AgentName 'CodeBuddy CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $QODER_FILE)    { if (-not (Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $SHAI_FILE)     { if (-not (Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI')) { $ok = $false }; $found = $true }
-    if (Test-Path $TABNINE_FILE)  { if (-not (Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $KIRO_FILE)     { if (-not (Update-AgentFile -TargetFile $KIRO_FILE     -AgentName 'Kiro CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $AGY_FILE)      { if (-not (Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity')) { $ok = $false }; $found = $true }
-    if (Test-Path $BOB_FILE)      { if (-not (Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob')) { $ok = $false }; $found = $true }
-    if (Test-Path $VIBE_FILE)     { if (-not (Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe')) { $ok = $false }; $found = $true }
-    if (Test-Path $KIMI_FILE)     { if (-not (Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $QODER_FILE) { if (-not (Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $SHAI_FILE) { if (-not (Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI')) { $ok = $false }; $found = $true }
+    if (Test-Path $TABNINE_FILE) { if (-not (Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $KIRO_FILE) { if (-not (Update-AgentFile -TargetFile $KIRO_FILE     -AgentName 'Kiro CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $AGY_FILE) { if (-not (Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity')) { $ok = $false }; $found = $true }
+    if (Test-Path $BOB_FILE) { if (-not (Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob')) { $ok = $false }; $found = $true }
+    if (Test-Path $VIBE_FILE) { if (-not (Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe')) { $ok = $false }; $found = $true }
+    if (Test-Path $KIMI_FILE) { if (-not (Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code')) { $ok = $false }; $found = $true }
     if (-not $found) {
         Write-Info 'No existing agent files found, creating default Claude file...'
         if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE -AgentName 'Claude Code')) { $ok = $false }

--- a/.specify/scripts/powershell/update-agent-context.ps1
+++ b/.specify/scripts/powershell/update-agent-context.ps1
@@ -9,7 +9,7 @@ Mirrors the behavior of scripts/bash/update-agent-context.sh:
  2. Plan Data Extraction
  3. Agent File Management (create from template or update existing)
  4. Content Generation (technology stack, recent changes, timestamp)
- 5. Multi-Agent Support (claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, roo, codebuddy, amp, shai, q, bob, qoder)
+ 5. Multi-Agent Support (claude, gemini, copilot, cursor-agent, qwen, opencode, codex, windsurf, kilocode, auggie, roo, codebuddy, amp, shai, tabnine, kiro-cli, agy, bob, vibe, qodercli, kimi, generic)
 
 .PARAMETER AgentType
 Optional agent key to update a single agent. If omitted, updates all existing agent files (creating a default Claude file if none exist).
@@ -24,8 +24,8 @@ Optional agent key to update a single agent. If omitted, updates all existing ag
 Relies on common helper functions in common.ps1
 #>
 param(
-    [Parameter(Position = 0)]
-    [ValidateSet('claude', 'gemini', 'copilot', 'cursor-agent', 'qwen', 'opencode', 'codex', 'windsurf', 'kilocode', 'auggie', 'roo', 'codebuddy', 'amp', 'shai', 'q', 'bob', 'qoder')]
+    [Parameter(Position=0)]
+    [ValidateSet('claude','gemini','copilot','cursor-agent','qwen','opencode','codex','windsurf','kilocode','auggie','roo','codebuddy','amp','shai','tabnine','kiro-cli','agy','bob','qodercli','vibe','kimi','generic')]
     [string]$AgentType
 )
 
@@ -37,29 +37,33 @@ $ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 # Acquire environment paths
 $envData = Get-FeaturePathsEnv
-$REPO_ROOT = $envData.REPO_ROOT
+$REPO_ROOT     = $envData.REPO_ROOT
 $CURRENT_BRANCH = $envData.CURRENT_BRANCH
-$HAS_GIT = $envData.HAS_GIT
-$IMPL_PLAN = $envData.IMPL_PLAN
+$HAS_GIT       = $envData.HAS_GIT
+$IMPL_PLAN     = $envData.IMPL_PLAN
 $NEW_PLAN = $IMPL_PLAN
 
 # Agent file paths
-$CLAUDE_FILE = Join-Path $REPO_ROOT 'CLAUDE.md'
-$GEMINI_FILE = Join-Path $REPO_ROOT 'GEMINI.md'
-$COPILOT_FILE = Join-Path $REPO_ROOT '.github/agents/copilot-instructions.md'
-$CURSOR_FILE = Join-Path $REPO_ROOT '.cursor/rules/specify-rules.mdc'
-$QWEN_FILE = Join-Path $REPO_ROOT 'QWEN.md'
-$AGENTS_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
+$CLAUDE_FILE   = Join-Path $REPO_ROOT 'CLAUDE.md'
+$GEMINI_FILE   = Join-Path $REPO_ROOT 'GEMINI.md'
+$COPILOT_FILE  = Join-Path $REPO_ROOT '.github/agents/copilot-instructions.md'
+$CURSOR_FILE   = Join-Path $REPO_ROOT '.cursor/rules/specify-rules.mdc'
+$QWEN_FILE     = Join-Path $REPO_ROOT 'QWEN.md'
+$AGENTS_FILE   = Join-Path $REPO_ROOT 'AGENTS.md'
 $WINDSURF_FILE = Join-Path $REPO_ROOT '.windsurf/rules/specify-rules.md'
 $KILOCODE_FILE = Join-Path $REPO_ROOT '.kilocode/rules/specify-rules.md'
-$AUGGIE_FILE = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
-$ROO_FILE = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
+$AUGGIE_FILE   = Join-Path $REPO_ROOT '.augment/rules/specify-rules.md'
+$ROO_FILE      = Join-Path $REPO_ROOT '.roo/rules/specify-rules.md'
 $CODEBUDDY_FILE = Join-Path $REPO_ROOT 'CODEBUDDY.md'
-$QODER_FILE = Join-Path $REPO_ROOT 'QODER.md'
-$AMP_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
-$SHAI_FILE = Join-Path $REPO_ROOT 'SHAI.md'
-$Q_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
-$BOB_FILE = Join-Path $REPO_ROOT 'AGENTS.md'
+$QODER_FILE    = Join-Path $REPO_ROOT 'QODER.md'
+$AMP_FILE      = Join-Path $REPO_ROOT 'AGENTS.md'
+$SHAI_FILE     = Join-Path $REPO_ROOT 'SHAI.md'
+$TABNINE_FILE  = Join-Path $REPO_ROOT 'TABNINE.md'
+$KIRO_FILE     = Join-Path $REPO_ROOT 'AGENTS.md'
+$AGY_FILE      = Join-Path $REPO_ROOT '.agent/rules/specify-rules.md'
+$BOB_FILE      = Join-Path $REPO_ROOT 'AGENTS.md'
+$VIBE_FILE     = Join-Path $REPO_ROOT '.vibe/agents/specify-agents.md'
+$KIMI_FILE     = Join-Path $REPO_ROOT 'KIMI.md'
 
 $TEMPLATE_FILE = Join-Path $REPO_ROOT '.specify/templates/agent-file-template.md'
 
@@ -69,36 +73,36 @@ $script:NEW_FRAMEWORK = ''
 $script:NEW_DB = ''
 $script:NEW_PROJECT_TYPE = ''
 
-function Write-Info {
+function Write-Info { 
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$Message
     )
-    Write-Host "INFO: $Message"
+    Write-Host "INFO: $Message" 
 }
 
-function Write-Success {
+function Write-Success { 
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$Message
     )
-    Write-Host "$([char]0x2713) $Message"
+    Write-Host "$([char]0x2713) $Message" 
 }
 
-function Write-WarningMsg {
+function Write-WarningMsg { 
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$Message
     )
-    Write-Warning $Message
+    Write-Warning $Message 
 }
 
-function Write-Err {
+function Write-Err { 
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$Message
     )
-    Write-Host "ERROR: $Message" -ForegroundColor Red
+    Write-Host "ERROR: $Message" -ForegroundColor Red 
 }
 
 function Validate-Environment {
@@ -122,32 +126,32 @@ function Validate-Environment {
 
 function Extract-PlanField {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$FieldPattern,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$PlanFile
     )
     if (-not (Test-Path $PlanFile)) { return '' }
     # Lines like **Language/Version**: Python 3.12
     $regex = "^\*\*$([Regex]::Escape($FieldPattern))\*\*: (.+)$"
     Get-Content -LiteralPath $PlanFile -Encoding utf8 | ForEach-Object {
-        if ($_ -match $regex) {
+        if ($_ -match $regex) { 
             $val = $Matches[1].Trim()
-            if ($val -notin @('NEEDS CLARIFICATION', 'N/A')) { return $val }
+            if ($val -notin @('NEEDS CLARIFICATION','N/A')) { return $val }
         }
     } | Select-Object -First 1
 }
 
 function Parse-PlanData {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$PlanFile
     )
     if (-not (Test-Path $PlanFile)) { Write-Err "Plan file not found: $PlanFile"; return $false }
     Write-Info "Parsing plan data from $PlanFile"
-    $script:NEW_LANG = Extract-PlanField -FieldPattern 'Language/Version' -PlanFile $PlanFile
-    $script:NEW_FRAMEWORK = Extract-PlanField -FieldPattern 'Primary Dependencies' -PlanFile $PlanFile
-    $script:NEW_DB = Extract-PlanField -FieldPattern 'Storage' -PlanFile $PlanFile
+    $script:NEW_LANG        = Extract-PlanField -FieldPattern 'Language/Version' -PlanFile $PlanFile
+    $script:NEW_FRAMEWORK   = Extract-PlanField -FieldPattern 'Primary Dependencies' -PlanFile $PlanFile
+    $script:NEW_DB          = Extract-PlanField -FieldPattern 'Storage' -PlanFile $PlanFile
     $script:NEW_PROJECT_TYPE = Extract-PlanField -FieldPattern 'Project Type' -PlanFile $PlanFile
 
     if ($NEW_LANG) { Write-Info "Found language: $NEW_LANG" } else { Write-WarningMsg 'No language information found in plan' }
@@ -159,29 +163,29 @@ function Parse-PlanData {
 
 function Format-TechnologyStack {
     param(
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [string]$Lang,
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [string]$Framework
     )
     $parts = @()
     if ($Lang -and $Lang -ne 'NEEDS CLARIFICATION') { $parts += $Lang }
-    if ($Framework -and $Framework -notin @('NEEDS CLARIFICATION', 'N/A')) { $parts += $Framework }
+    if ($Framework -and $Framework -notin @('NEEDS CLARIFICATION','N/A')) { $parts += $Framework }
     if (-not $parts) { return '' }
     return ($parts -join ' + ')
 }
 
-function Get-ProjectStructure {
+function Get-ProjectStructure { 
     param(
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [string]$ProjectType
     )
-    if ($ProjectType -match 'web') { return "backend/`nfrontend/`ntests/" } else { return "src/`ntests/" }
+    if ($ProjectType -match 'web') { return "backend/`nfrontend/`ntests/" } else { return "src/`ntests/" } 
 }
 
-function Get-CommandsForLanguage {
+function Get-CommandsForLanguage { 
     param(
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [string]$Lang
     )
     switch -Regex ($Lang) {
@@ -192,21 +196,21 @@ function Get-CommandsForLanguage {
     }
 }
 
-function Get-LanguageConventions {
+function Get-LanguageConventions { 
     param(
-        [Parameter(Mandatory = $false)]
+        [Parameter(Mandatory=$false)]
         [string]$Lang
     )
-    if ($Lang) { "${Lang}: Follow standard conventions" } else { 'General: Follow standard conventions' }
+    if ($Lang) { "${Lang}: Follow standard conventions" } else { 'General: Follow standard conventions' } 
 }
 
 function New-AgentFile {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$TargetFile,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$ProjectName,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [datetime]$Date
     )
     if (-not (Test-Path $TEMPLATE_FILE)) { Write-Err "Template not found at $TEMPLATE_FILE"; return $false }
@@ -222,44 +226,46 @@ function New-AgentFile {
     $escaped_branch = $CURRENT_BRANCH
 
     $content = Get-Content -LiteralPath $temp -Raw -Encoding utf8
-    $content = $content -replace '\[PROJECT NAME\]', $ProjectName
-    $content = $content -replace '\[DATE\]', $Date.ToString('yyyy-MM-dd')
-
+    $content = $content -replace '\[PROJECT NAME\]',$ProjectName
+    $content = $content -replace '\[DATE\]',$Date.ToString('yyyy-MM-dd')
+    
     # Build the technology stack string safely
     $techStackForTemplate = ""
     if ($escaped_lang -and $escaped_framework) {
         $techStackForTemplate = "- $escaped_lang + $escaped_framework ($escaped_branch)"
-    }
-    elseif ($escaped_lang) {
+    } elseif ($escaped_lang) {
         $techStackForTemplate = "- $escaped_lang ($escaped_branch)"
-    }
-    elseif ($escaped_framework) {
+    } elseif ($escaped_framework) {
         $techStackForTemplate = "- $escaped_framework ($escaped_branch)"
     }
-
-    $content = $content -replace '\[EXTRACTED FROM ALL PLAN.MD FILES\]', $techStackForTemplate
+    
+    $content = $content -replace '\[EXTRACTED FROM ALL PLAN.MD FILES\]',$techStackForTemplate
     # For project structure we manually embed (keep newlines)
     $escapedStructure = [Regex]::Escape($projectStructure)
-    $content = $content -replace '\[ACTUAL STRUCTURE FROM PLANS\]', $escapedStructure
+    $content = $content -replace '\[ACTUAL STRUCTURE FROM PLANS\]',$escapedStructure
     # Replace escaped newlines placeholder after all replacements
-    $content = $content -replace '\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]', $commands
-    $content = $content -replace '\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]', $languageConventions
-
+    $content = $content -replace '\[ONLY COMMANDS FOR ACTIVE TECHNOLOGIES\]',$commands
+    $content = $content -replace '\[LANGUAGE-SPECIFIC, ONLY FOR LANGUAGES IN USE\]',$languageConventions
+    
     # Build the recent changes string safely
     $recentChangesForTemplate = ""
     if ($escaped_lang -and $escaped_framework) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_lang} + ${escaped_framework}"
-    }
-    elseif ($escaped_lang) {
+    } elseif ($escaped_lang) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_lang}"
-    }
-    elseif ($escaped_framework) {
+    } elseif ($escaped_framework) {
         $recentChangesForTemplate = "- ${escaped_branch}: Added ${escaped_framework}"
     }
-
-    $content = $content -replace '\[LAST 3 FEATURES AND WHAT THEY ADDED\]', $recentChangesForTemplate
+    
+    $content = $content -replace '\[LAST 3 FEATURES AND WHAT THEY ADDED\]',$recentChangesForTemplate
     # Convert literal \n sequences introduced by Escape to real newlines
-    $content = $content -replace '\\n', [Environment]::NewLine
+    $content = $content -replace '\\n',[Environment]::NewLine
+
+    # Prepend Cursor frontmatter for .mdc files so rules are auto-included
+    if ($TargetFile -match '\.mdc$') {
+        $frontmatter = @('---','description: Project Development Guidelines','globs: ["**/*"]','alwaysApply: true','---','') -join [Environment]::NewLine
+        $content = $frontmatter + $content
+    }
 
     $parent = Split-Path -Parent $TargetFile
     if (-not (Test-Path $parent)) { New-Item -ItemType Directory -Path $parent | Out-Null }
@@ -270,9 +276,9 @@ function New-AgentFile {
 
 function Update-ExistingAgentFile {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$TargetFile,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [datetime]$Date
     )
     if (-not (Test-Path $TargetFile)) { return (New-AgentFile -TargetFile $TargetFile -ProjectName (Split-Path $REPO_ROOT -Leaf) -Date $Date) }
@@ -281,25 +287,25 @@ function Update-ExistingAgentFile {
     $newTechEntries = @()
     if ($techStack) {
         $escapedTechStack = [Regex]::Escape($techStack)
-        if (-not (Select-String -Pattern $escapedTechStack -Path $TargetFile -Quiet)) {
-            $newTechEntries += "- $techStack ($CURRENT_BRANCH)"
+        if (-not (Select-String -Pattern $escapedTechStack -Path $TargetFile -Quiet)) { 
+            $newTechEntries += "- $techStack ($CURRENT_BRANCH)" 
         }
     }
-    if ($NEW_DB -and $NEW_DB -notin @('N/A', 'NEEDS CLARIFICATION')) {
+    if ($NEW_DB -and $NEW_DB -notin @('N/A','NEEDS CLARIFICATION')) {
         $escapedDB = [Regex]::Escape($NEW_DB)
-        if (-not (Select-String -Pattern $escapedDB -Path $TargetFile -Quiet)) {
-            $newTechEntries += "- $NEW_DB ($CURRENT_BRANCH)"
+        if (-not (Select-String -Pattern $escapedDB -Path $TargetFile -Quiet)) { 
+            $newTechEntries += "- $NEW_DB ($CURRENT_BRANCH)" 
         }
     }
     $newChangeEntry = ''
     if ($techStack) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${techStack}" }
-    elseif ($NEW_DB -and $NEW_DB -notin @('N/A', 'NEEDS CLARIFICATION')) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${NEW_DB}" }
+    elseif ($NEW_DB -and $NEW_DB -notin @('N/A','NEEDS CLARIFICATION')) { $newChangeEntry = "- ${CURRENT_BRANCH}: Added ${NEW_DB}" }
 
     $lines = Get-Content -LiteralPath $TargetFile -Encoding utf8
     $output = New-Object System.Collections.Generic.List[string]
     $inTech = $false; $inChanges = $false; $techAdded = $false; $changeAdded = $false; $existingChanges = 0
 
-    for ($i = 0; $i -lt $lines.Count; $i++) {
+    for ($i=0; $i -lt $lines.Count; $i++) {
         $line = $lines[$i]
         if ($line -eq '## Active Technologies') {
             $output.Add($line)
@@ -325,8 +331,8 @@ function Update-ExistingAgentFile {
             if ($existingChanges -lt 2) { $output.Add($line); $existingChanges++ }
             continue
         }
-        if ($line -match '\*\*Last updated\*\*: .*\d{4}-\d{2}-\d{2}') {
-            $output.Add(($line -replace '\d{4}-\d{2}-\d{2}', $Date.ToString('yyyy-MM-dd')))
+        if ($line -match '(\*\*)?Last updated(\*\*)?: .*\d{4}-\d{2}-\d{2}') {
+            $output.Add(($line -replace '\d{4}-\d{2}-\d{2}',$Date.ToString('yyyy-MM-dd')))
             continue
         }
         $output.Add($line)
@@ -337,15 +343,21 @@ function Update-ExistingAgentFile {
         $newTechEntries | ForEach-Object { $output.Add($_) }
     }
 
+    # Ensure Cursor .mdc files have YAML frontmatter for auto-inclusion
+    if ($TargetFile -match '\.mdc$' -and $output.Count -gt 0 -and $output[0] -ne '---') {
+        $frontmatter = @('---','description: Project Development Guidelines','globs: ["**/*"]','alwaysApply: true','---','')
+        $output.InsertRange(0, $frontmatter)
+    }
+
     Set-Content -LiteralPath $TargetFile -Value ($output -join [Environment]::NewLine) -Encoding utf8
     return $true
 }
 
 function Update-AgentFile {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$TargetFile,
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$AgentName
     )
     if (-not $TargetFile -or -not $AgentName) { Write-Err 'Update-AgentFile requires TargetFile and AgentName'; return $false }
@@ -358,12 +370,10 @@ function Update-AgentFile {
 
     if (-not (Test-Path $TargetFile)) {
         if (New-AgentFile -TargetFile $TargetFile -ProjectName $projectName -Date $date) { Write-Success "Created new $AgentName context file" } else { Write-Err 'Failed to create new agent file'; return $false }
-    }
-    else {
+    } else {
         try {
             if (Update-ExistingAgentFile -TargetFile $TargetFile -Date $date) { Write-Success "Updated existing $AgentName context file" } else { Write-Err 'Failed to update agent file'; return $false }
-        }
-        catch {
+        } catch {
             Write-Err "Cannot access or update existing file: $TargetFile. $_"
             return $false
         }
@@ -373,49 +383,58 @@ function Update-AgentFile {
 
 function Update-SpecificAgent {
     param(
-        [Parameter(Mandatory = $true)]
+        [Parameter(Mandatory=$true)]
         [string]$Type
     )
     switch ($Type) {
-        'claude' { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
-        'gemini' { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
-        'copilot' { Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot' }
+        'claude'   { Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code' }
+        'gemini'   { Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI' }
+        'copilot'  { Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot' }
         'cursor-agent' { Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE' }
-        'qwen' { Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code' }
+        'qwen'     { Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code' }
         'opencode' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'opencode' }
-        'codex' { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
+        'codex'    { Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex CLI' }
         'windsurf' { Update-AgentFile -TargetFile $WINDSURF_FILE -AgentName 'Windsurf' }
         'kilocode' { Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code' }
-        'auggie' { Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI' }
-        'roo' { Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code' }
+        'auggie'   { Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI' }
+        'roo'      { Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code' }
         'codebuddy' { Update-AgentFile -TargetFile $CODEBUDDY_FILE -AgentName 'CodeBuddy CLI' }
-        'qoder' { Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI' }
-        'amp' { Update-AgentFile -TargetFile $AMP_FILE      -AgentName 'Amp' }
-        'shai' { Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI' }
-        'q' { Update-AgentFile -TargetFile $Q_FILE        -AgentName 'Amazon Q Developer CLI' }
-        'bob' { Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob' }
-        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|q|bob|qoder'; return $false }
+        'qodercli' { Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI' }
+        'amp'      { Update-AgentFile -TargetFile $AMP_FILE      -AgentName 'Amp' }
+        'shai'     { Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI' }
+        'tabnine'  { Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI' }
+        'kiro-cli' { Update-AgentFile -TargetFile $KIRO_FILE     -AgentName 'Kiro CLI' }
+        'agy'      { Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity' }
+        'bob'      { Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob' }
+        'vibe'     { Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe' }
+        'kimi'     { Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code' }
+        'generic'  { Write-Info 'Generic agent: no predefined context file. Use the agent-specific update script for your agent.' }
+        default { Write-Err "Unknown agent type '$Type'"; Write-Err 'Expected: claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|kimi|generic'; return $false }
     }
 }
 
 function Update-AllExistingAgents {
     $found = $false
     $ok = $true
-    if (Test-Path $CLAUDE_FILE) { if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $GEMINI_FILE) { if (-not (Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $COPILOT_FILE) { if (-not (Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot')) { $ok = $false }; $found = $true }
-    if (Test-Path $CURSOR_FILE) { if (-not (Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE')) { $ok = $false }; $found = $true }
-    if (Test-Path $QWEN_FILE) { if (-not (Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $AGENTS_FILE) { if (-not (Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex/opencode')) { $ok = $false }; $found = $true }
+    if (Test-Path $CLAUDE_FILE)   { if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE   -AgentName 'Claude Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $GEMINI_FILE)   { if (-not (Update-AgentFile -TargetFile $GEMINI_FILE   -AgentName 'Gemini CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $COPILOT_FILE)  { if (-not (Update-AgentFile -TargetFile $COPILOT_FILE  -AgentName 'GitHub Copilot')) { $ok = $false }; $found = $true }
+    if (Test-Path $CURSOR_FILE)   { if (-not (Update-AgentFile -TargetFile $CURSOR_FILE   -AgentName 'Cursor IDE')) { $ok = $false }; $found = $true }
+    if (Test-Path $QWEN_FILE)     { if (-not (Update-AgentFile -TargetFile $QWEN_FILE     -AgentName 'Qwen Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $AGENTS_FILE)   { if (-not (Update-AgentFile -TargetFile $AGENTS_FILE   -AgentName 'Codex/opencode')) { $ok = $false }; $found = $true }
     if (Test-Path $WINDSURF_FILE) { if (-not (Update-AgentFile -TargetFile $WINDSURF_FILE -AgentName 'Windsurf')) { $ok = $false }; $found = $true }
     if (Test-Path $KILOCODE_FILE) { if (-not (Update-AgentFile -TargetFile $KILOCODE_FILE -AgentName 'Kilo Code')) { $ok = $false }; $found = $true }
-    if (Test-Path $AUGGIE_FILE) { if (-not (Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $ROO_FILE) { if (-not (Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code')) { $ok = $false }; $found = $true }
+    if (Test-Path $AUGGIE_FILE)   { if (-not (Update-AgentFile -TargetFile $AUGGIE_FILE   -AgentName 'Auggie CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $ROO_FILE)      { if (-not (Update-AgentFile -TargetFile $ROO_FILE      -AgentName 'Roo Code')) { $ok = $false }; $found = $true }
     if (Test-Path $CODEBUDDY_FILE) { if (-not (Update-AgentFile -TargetFile $CODEBUDDY_FILE -AgentName 'CodeBuddy CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $QODER_FILE) { if (-not (Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $SHAI_FILE) { if (-not (Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI')) { $ok = $false }; $found = $true }
-    if (Test-Path $Q_FILE) { if (-not (Update-AgentFile -TargetFile $Q_FILE        -AgentName 'Amazon Q Developer CLI')) { $ok = $false }; $found = $true }
-    if (Test-Path $BOB_FILE) { if (-not (Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob')) { $ok = $false }; $found = $true }
+    if (Test-Path $QODER_FILE)    { if (-not (Update-AgentFile -TargetFile $QODER_FILE    -AgentName 'Qoder CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $SHAI_FILE)     { if (-not (Update-AgentFile -TargetFile $SHAI_FILE     -AgentName 'SHAI')) { $ok = $false }; $found = $true }
+    if (Test-Path $TABNINE_FILE)  { if (-not (Update-AgentFile -TargetFile $TABNINE_FILE  -AgentName 'Tabnine CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $KIRO_FILE)     { if (-not (Update-AgentFile -TargetFile $KIRO_FILE     -AgentName 'Kiro CLI')) { $ok = $false }; $found = $true }
+    if (Test-Path $AGY_FILE)      { if (-not (Update-AgentFile -TargetFile $AGY_FILE      -AgentName 'Antigravity')) { $ok = $false }; $found = $true }
+    if (Test-Path $BOB_FILE)      { if (-not (Update-AgentFile -TargetFile $BOB_FILE      -AgentName 'IBM Bob')) { $ok = $false }; $found = $true }
+    if (Test-Path $VIBE_FILE)     { if (-not (Update-AgentFile -TargetFile $VIBE_FILE     -AgentName 'Mistral Vibe')) { $ok = $false }; $found = $true }
+    if (Test-Path $KIMI_FILE)     { if (-not (Update-AgentFile -TargetFile $KIMI_FILE     -AgentName 'Kimi Code')) { $ok = $false }; $found = $true }
     if (-not $found) {
         Write-Info 'No existing agent files found, creating default Claude file...'
         if (-not (Update-AgentFile -TargetFile $CLAUDE_FILE -AgentName 'Claude Code')) { $ok = $false }
@@ -430,7 +449,7 @@ function Print-Summary {
     if ($NEW_FRAMEWORK) { Write-Host "  - Added framework: $NEW_FRAMEWORK" }
     if ($NEW_DB -and $NEW_DB -ne 'N/A') { Write-Host "  - Added database: $NEW_DB" }
     Write-Host ''
-    Write-Info 'Usage: ./update-agent-context.ps1 [-AgentType claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|q|bob|qoder]'
+    Write-Info 'Usage: ./update-agent-context.ps1 [-AgentType claude|gemini|copilot|cursor-agent|qwen|opencode|codex|windsurf|kilocode|auggie|roo|codebuddy|amp|shai|tabnine|kiro-cli|agy|bob|vibe|qodercli|generic]'
 }
 
 function Main {
@@ -451,4 +470,3 @@ function Main {
 }
 
 Main
-

--- a/.specify/templates/constitution-template.md
+++ b/.specify/templates/constitution-template.md
@@ -1,0 +1,50 @@
+# [PROJECT_NAME] Constitution
+<!-- Example: Spec Constitution, TaskFlow Constitution, etc. -->
+
+## Core Principles
+
+### [PRINCIPLE_1_NAME]
+<!-- Example: I. Library-First -->
+[PRINCIPLE_1_DESCRIPTION]
+<!-- Example: Every feature starts as a standalone library; Libraries must be self-contained, independently testable, documented; Clear purpose required - no organizational-only libraries -->
+
+### [PRINCIPLE_2_NAME]
+<!-- Example: II. CLI Interface -->
+[PRINCIPLE_2_DESCRIPTION]
+<!-- Example: Every library exposes functionality via CLI; Text in/out protocol: stdin/args → stdout, errors → stderr; Support JSON + human-readable formats -->
+
+### [PRINCIPLE_3_NAME]
+<!-- Example: III. Test-First (NON-NEGOTIABLE) -->
+[PRINCIPLE_3_DESCRIPTION]
+<!-- Example: TDD mandatory: Tests written → User approved → Tests fail → Then implement; Red-Green-Refactor cycle strictly enforced -->
+
+### [PRINCIPLE_4_NAME]
+<!-- Example: IV. Integration Testing -->
+[PRINCIPLE_4_DESCRIPTION]
+<!-- Example: Focus areas requiring integration tests: New library contract tests, Contract changes, Inter-service communication, Shared schemas -->
+
+### [PRINCIPLE_5_NAME]
+<!-- Example: V. Observability, VI. Versioning & Breaking Changes, VII. Simplicity -->
+[PRINCIPLE_5_DESCRIPTION]
+<!-- Example: Text I/O ensures debuggability; Structured logging required; Or: MAJOR.MINOR.BUILD format; Or: Start simple, YAGNI principles -->
+
+## [SECTION_2_NAME]
+<!-- Example: Additional Constraints, Security Requirements, Performance Standards, etc. -->
+
+[SECTION_2_CONTENT]
+<!-- Example: Technology stack requirements, compliance standards, deployment policies, etc. -->
+
+## [SECTION_3_NAME]
+<!-- Example: Development Workflow, Review Process, Quality Gates, etc. -->
+
+[SECTION_3_CONTENT]
+<!-- Example: Code review requirements, testing gates, deployment approval process, etc. -->
+
+## Governance
+<!-- Example: Constitution supersedes all other practices; Amendments require documentation, approval, migration plan -->
+
+[GOVERNANCE_RULES]
+<!-- Example: All PRs/reviews must verify compliance; Complexity must be justified; Use [GUIDANCE_FILE] for runtime development guidance -->
+
+**Version**: [CONSTITUTION_VERSION] | **Ratified**: [RATIFICATION_DATE] | **Last Amended**: [LAST_AMENDED_DATE]
+<!-- Example: Version: 2.1.1 | Ratified: 2025-06-13 | Last Amended: 2025-07-16 -->

--- a/.specify/templates/plan-template.md
+++ b/.specify/templates/plan-template.md
@@ -3,7 +3,7 @@
 **Branch**: `[###-feature-name]` | **Date**: [DATE] | **Spec**: [link]
 **Input**: Feature specification from `/specs/[###-feature-name]/spec.md`
 
-**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/commands/plan.md` for the execution workflow.
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
 
 ## Summary
 
@@ -19,10 +19,10 @@
 
 **Language/Version**: [e.g., Python 3.11, Swift 5.9, Rust 1.75 or NEEDS CLARIFICATION]
 **Primary Dependencies**: [e.g., FastAPI, UIKit, LLVM or NEEDS CLARIFICATION]
-**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]
-**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]
+**Storage**: [if applicable, e.g., PostgreSQL, CoreData, files or N/A]  
+**Testing**: [e.g., pytest, XCTest, cargo test or NEEDS CLARIFICATION]  
 **Target Platform**: [e.g., Linux server, iOS 15+, WASM or NEEDS CLARIFICATION]
-**Project Type**: [single/web/mobile - determines source structure]
+**Project Type**: [e.g., library/cli/web-service/mobile-app/compiler/desktop-app or NEEDS CLARIFICATION]  
 **Performance Goals**: [domain-specific, e.g., 1000 req/s, 10k lines/sec, 60 fps or NEEDS CLARIFICATION]
 **Constraints**: [domain-specific, e.g., <200ms p95, <100MB memory, offline-capable or NEEDS CLARIFICATION]
 **Scale/Scope**: [domain-specific, e.g., 10k users, 1M LOC, 50 screens or NEEDS CLARIFICATION]


### PR DESCRIPTION
## Summary

Upgrades the Spec Kit tooling to version 0.3.0, updating bash and PowerShell scripts, GitHub Copilot agent definitions, and spec templates.

## Changes

### Agent updates (`.github/agents/`)
- Minor updates to `speckit.analyze`, `speckit.clarify`, and `speckit.constitution` agents
- Significant rework of `speckit.implement`, `speckit.plan`, `speckit.specify`, `speckit.tasks`, and `speckit.checklist` agents

### Bash scripts (`.specify/scripts/bash/`)
- Reformatted all scripts with `shfmt`
- Updated `common.sh` with expanded utility functions
- Reworked `check-prerequisites.sh`, `create-new-feature.sh`, `setup-plan.sh`, and `update-agent-context.sh`

### PowerShell scripts (`.specify/scripts/powershell/`)
- Updated `common.ps1`, `check-prerequisites.ps1`, `create-new-feature.ps1`, `setup-plan.ps1`, and `update-agent-context.ps1`

### Templates and configuration
- Added `.specify/init-options.json` recording Spec Kit 0.3.0 init settings
- Added `.specify/templates/constitution-template.md` for project constitutions
- Updated `.specify/templates/plan-template.md` with corrected links and expanded project type options